### PR TITLE
feat: complete Phase 4 - Session Management with Enhanced CLI Experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,26 @@ ALWAYS run tests before committing:
 - Mock external services (OCI, APIs)
 - Aim for >80% coverage on new code
 
+### Mock Provider for Testing
+
+**IMPORTANT**: Use `MockProvider` for all tests requiring AI responses. Never use real providers in tests.
+
+```python
+from coda.providers import MockProvider, Message, Role
+
+# Use MockProvider for predictable, offline testing
+provider = MockProvider()
+response = provider.chat(messages, "mock-echo")
+```
+
+**Key Benefits**:
+- ✅ No API keys or network required
+- ✅ Predictable, deterministic responses
+- ✅ Context-aware conversation memory
+- ✅ Perfect for session management testing
+
+**Reference**: See [docs/mock_provider_reference.md](docs/mock_provider_reference.md) for complete behavior patterns and testing examples.
+
 ## Provider Implementation
 
 When adding new providers:

--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ uv run coda
 
 ## 📖 Documentation
 
-For comprehensive documentation, visit our **[Wiki](https://github.com/dannyl1u/coda-code-assistant/wiki)**:
+For comprehensive documentation, visit our **[Wiki](https://github.com/djvolz/coda-code-assistant/wiki)**:
 
-- **[Getting Started Guide](https://github.com/dannyl1u/coda-code-assistant/wiki/Getting-Started)** - Installation and setup
-- **[User Guide](https://github.com/dannyl1u/coda-code-assistant/wiki/User-Guide)** - How to use Coda effectively
-- **[AI Modes](https://github.com/dannyl1u/coda-code-assistant/wiki/AI-Modes)** - Specialized AI personalities
-- **[Configuration](https://github.com/dannyl1u/coda-code-assistant/wiki/Configuration)** - Provider setup and customization
-- **[Troubleshooting](https://github.com/dannyl1u/coda-code-assistant/wiki/Troubleshooting)** - Common issues and solutions
+- **[Getting Started Guide](https://github.com/djvolz/coda-code-assistant/wiki/Getting-Started)** - Installation and setup
+- **[AI Modes](https://github.com/djvolz/coda-code-assistant/wiki/AI-Modes)** - Specialized AI personalities
+- **[Development Guide](https://github.com/djvolz/coda-code-assistant/wiki/Development-Guide)** - Contributing and development workflow
+- **[Troubleshooting](https://github.com/djvolz/coda-code-assistant/wiki/Troubleshooting)** - Common issues and solutions
 
 ## 🎯 Key Features
 
@@ -59,10 +58,10 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔗 Links
 
-- [Full Documentation](https://github.com/dannyl1u/coda-code-assistant/wiki)
-- [Issue Tracker](https://github.com/dannyl1u/coda-code-assistant/issues)
-- [Discussions](https://github.com/dannyl1u/coda-code-assistant/discussions)
-- [Roadmap](https://github.com/dannyl1u/coda-code-assistant/wiki/Roadmap)
+- [Full Documentation](https://github.com/djvolz/coda-code-assistant/wiki)
+- [Issue Tracker](https://github.com/djvolz/coda-code-assistant/issues)
+- [Discussions](https://github.com/djvolz/coda-code-assistant/discussions)
+- [Roadmap](https://github.com/djvolz/coda-code-assistant/blob/main/ROADMAP.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,33 +8,19 @@
 
 ---
 
-Coda seamlessly integrates with multiple AI providers while maintaining a consistent, developer-friendly interface.
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ## ✨ What is Coda?
 
-Coda is your AI pair programmer that:
-- 🚀 **Lives in your terminal**: Works right where you code, integrated into your development workflow
-- 🔌 **Connects to any AI**: Use Oracle OCI GenAI, local Ollama models, OpenAI, Anthropic, or any LiteLLM-supported provider
-- 💻 **Thinks like a developer**: Specialized modes for writing, debugging, explaining, and reviewing code
-- 🔄 **Remembers context**: Save and resume conversations, branch off interesting threads
-- 🛠️ **Takes action**: Integrated tools for file operations, web searches, and more via Model Context Protocol (MCP)
+Coda is your AI pair programmer that lives in your terminal, supporting multiple AI providers including Oracle OCI GenAI, OpenAI, Anthropic, Google, and 100+ more via LiteLLM.
 
-## 🎯 Key Features
-
-- 🌐 **Multi-Provider Support**: Oracle OCI GenAI, Ollama (local), OpenAI, Anthropic, Google, and 100+ more via LiteLLM
-- 💻 **CLI-First Design**: Built for developers who live in the terminal
-- 🧠 **[Smart Modes](docs/modes.md)**: Specialized AI personalities for different tasks (code, debug, explain, review)
-- 💾 **Session Management**: Never lose a conversation - save, resume, and branch discussions
-- 🎨 **Beautiful Interface**: Rich terminal UI with syntax highlighting and multiple themes
-- ⚡ **Real-time Streaming**: See responses as they're generated
-- 🔧 **Tool Integration**: File operations, web search, and custom tools via MCP
-- 🌈 **Customizable**: Themes, key bindings, and behavior settings
-
-## 📦 Installation
+## 🚀 Quick Start
 
 ```bash
 # Clone the repository
-git clone https://github.com/djvolz/coda-code-assistant.git
+git clone https://github.com/dannyl1u/coda-code-assistant.git
 cd coda-code-assistant
 
 # Install with uv (recommended)
@@ -44,161 +30,40 @@ uv sync
 uv run coda
 ```
 
-## 🚀 Quick Start
+## 📖 Documentation
 
-### Basic Usage
+For comprehensive documentation, visit our **[Wiki](https://github.com/dannyl1u/coda-code-assistant/wiki)**:
 
-```bash
-# Start interactive chat with OCI GenAI (auto-selects model)
-uv run coda
+- **[Getting Started Guide](https://github.com/dannyl1u/coda-code-assistant/wiki/Getting-Started)** - Installation and setup
+- **[User Guide](https://github.com/dannyl1u/coda-code-assistant/wiki/User-Guide)** - How to use Coda effectively
+- **[AI Modes](https://github.com/dannyl1u/coda-code-assistant/wiki/AI-Modes)** - Specialized AI personalities
+- **[Configuration](https://github.com/dannyl1u/coda-code-assistant/wiki/Configuration)** - Provider setup and customization
+- **[Troubleshooting](https://github.com/dannyl1u/coda-code-assistant/wiki/Troubleshooting)** - Common issues and solutions
 
-# Use a specific model
-uv run coda --model cohere.command-r-plus-08-2024
+## 🎯 Key Features
 
-# One-shot command (no interaction needed)
-uv run coda --one-shot "What is the capital of France?"
-
-# Enable debug output
-uv run coda --debug
-```
-
-### Provider Setup
-
-#### 🏠 Ollama (Local, No API Key Required)
-```bash
-# Install Ollama from https://ollama.ai
-ollama pull llama3.1
-ollama serve  # Run in separate terminal
-uv run coda --provider ollama
-```
-
-#### ☁️ Oracle OCI GenAI
-```bash
-# Set compartment ID via environment variable
-export OCI_COMPARTMENT_ID="ocid1.compartment.oc1..."
-uv run coda --provider oci_genai --model cohere.command-r-plus
-
-# Or configure in ~/.config/coda/config.toml:
-# [providers.oci_genai]
-# compartment_id = "ocid1.compartment.oc1..."
-```
-
-#### 🤖 OpenAI
-```bash
-export OPENAI_API_KEY="sk-..."
-uv run coda --provider openai --model gpt-4
-```
-
-## 💡 Usage Examples
-
-### Developer Modes
-```bash
-# Start with a specific mode
-uv run coda --mode code
-
-# Switch modes during conversation
-You: /mode debug
-You: Why am I getting "undefined is not a function"?
-
-You: /mode explain  
-You: How does async/await work in JavaScript?
-
-You: /mode review
-You: Check this SQL query for security issues: SELECT * FROM users WHERE id = ${userId}
-```
-
-See the [Developer Modes Guide](docs/modes.md) for detailed information about each mode.
-
-### Session Management
-```bash
-# Save your conversation
-/sessions save my-feature-discussion
-
-# List previous sessions
-/sessions list
-
-# Resume a session
-/sessions load my-feature-discussion
-```
-
-### Customization
-```bash
-# Change theme
-/theme dracula
-
-# Export conversation
-/export markdown conversation.md
-
-# Configure settings
-/config edit
-```
-
-## 🛠️ Development
-
-```bash
-# Install development dependencies
-uv sync --dev
-
-# Run tests
-uv run pytest
-
-# Format code
-uv run black .
-uv run ruff check --fix .
-
-# Type checking
-uv run mypy coda
-```
-
-## 🏗️ Architecture
-
-Coda is built with a modular architecture:
-
-```
-coda/
-├── core/       # Core chat engine and session management
-├── providers/  # AI provider implementations
-├── cli/        # Terminal interface and commands
-├── tools/      # MCP tool integrations
-├── config/     # Configuration management
-└── utils/      # Shared utilities
-```
-
-## 📚 Documentation
-
-- [Developer Modes Guide](docs/modes.md) - Complete guide to using specialized AI modes
-- [Roadmap](ROADMAP.md) - Roadmap and technical architecture
-- [OCI GenAI Integration](docs/oci-genai-integration.md) - Deep dive into Oracle Cloud integration
-- [Test Suite Documentation](tests/README.md) - Testing strategy and guidelines
-- [AI Assistant Guidelines](AGENTS.md) - Guidelines for AI-assisted development
+- 🌐 **Multi-Provider Support**: Works with Oracle OCI GenAI, Ollama, OpenAI, Anthropic, Google, and 100+ providers
+- 💻 **Terminal-First**: Designed for developers who live in the command line
+- 🧠 **Smart AI Modes**: Specialized modes for coding, debugging, explaining, and reviewing
+- 💾 **Session Management**: Save, resume, and branch conversations
+- 🎨 **Beautiful Interface**: Rich terminal UI with syntax highlighting
+- 🔧 **Tool Integration**: File operations, web search, and more via MCP
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) and check out our [AGENTS.md](AGENTS.md) file for AI-assisted development guidelines.
+We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
-### Commit Convention
-We use [Conventional Commits](https://www.conventionalcommits.org/) for automated releases. Format:
-```
-feat(scope): add new feature
-fix(scope): fix bug
-```
+## 📄 License
 
-## 🏷️ Versioning
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-Coda uses date-based versioning in the format: `year.month.day.HHMM`
+## 🔗 Links
 
-- Example: `2025.1.3.1430` for January 3, 2025 at 14:30 UTC
-- To update version: `make version`
-- Version is automatically shown in CLI with `coda --version`
+- [Full Documentation](https://github.com/dannyl1u/coda-code-assistant/wiki)
+- [Issue Tracker](https://github.com/dannyl1u/coda-code-assistant/issues)
+- [Discussions](https://github.com/dannyl1u/coda-code-assistant/discussions)
+- [Roadmap](https://github.com/dannyl1u/coda-code-assistant/wiki/Roadmap)
 
-## 📝 License
+---
 
-MIT License - see [LICENSE](LICENSE) file for details
-
-## 🙏 Acknowledgments
-
-Built with:
-- [LiteLLM](https://github.com/BerriAI/litellm) - Unified LLM API
-- [Rich](https://github.com/Textualize/rich) - Beautiful terminal formatting
-- [Prompt Toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) - Advanced CLI interactions
-- [Model Context Protocol](https://modelcontext.dev/) - Tool integration standard
+<p align="center">Made with ❤️ by the Coda community</p>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,16 +1,19 @@
 # Coda Roadmap
 
 ## Project Vision
+
 Build a multi-provider, CLI-focused code assistant that provides a unified interface for AI-powered development across Oracle OCI GenAI, Ollama, and other LiteLLM-supported providers.
 
 ## Current State & Priorities
 
 ✅ **Completed Phases**:
+
 - **Phase 1**: Native OCI GenAI Integration (30+ models, streaming, dynamic discovery)
 - **Phase 2**: Core Provider Architecture (LiteLLM, Ollama, provider registry)
 - **Phase 3**: Enhanced CLI Experience (interactive shell, slash commands, developer modes)
 
-✅ **Phase 4**: Session Management - COMPLETED (July 5, 2025) | 🚧 Enhancement 4.5 Pending
+✅ **Phase 4**: Session Management - COMPLETED (July 5, 2025) | 🚧 Enhancements 4.5 & 4.6 Pending
+
 - SQLite persistence layer (stored in ~/.cache/coda/sessions.db)
 - Session commands (/session save/load/list/branch/delete/info/search)
 - Export commands (/export json/markdown/txt/html)
@@ -18,34 +21,41 @@ Build a multi-provider, CLI-focused code assistant that provides a unified inter
 - Context optimization for token limits
 - MockProvider for deterministic testing
 
-🚧 **Current Focus**: Phase 5 - Tool Integration (MCP) - Target: July 12
+🚧 **Current Focus**: Phase 4.6 - Code Quality Refactoring - Before Phase 5
+
+📅 **Next**: Phase 5 - Tool Integration (MCP) - Target: July 12
 
 📅 **Upcoming**:
+
 - Phase 6: Advanced Features - July 15
 - Phase 7: Web UI (Streamlit)
 - Phase 8: Additional features
 
 ## Reference Directories
+
 Key directories for OCI GenAI implementation reference:
+
 - **LangChain OCI Integration**: `/Users/danny/Developer/forks/litellm-oci-using-claude/langchain-community`
 - **OCI Python SDK**: `/Users/danny/Developer/forks/litellm-oci-using-claude/oci-python-sdk`
 - **LiteLLM Fork with OCI**: `/Users/danny/Developer/forks/litellm-oci-using-claude/litellm`
 
-
 ## Bugs & Fixes (Top Priority - Must be addressed before any phase work)
 
 ### Active Bugs
+
 None currently - all bugs have been resolved!
 
 ## Phase 1: Native OCI GenAI Integration (Current Priority)
 
 ### 1.1 Study Reference Implementations
+
 - [x] Review LangChain OCI integration patterns
 - [x] Understand OCI Python SDK usage for GenAI
 - [x] Analyze LiteLLM fork's OCI implementation
 - [x] Document key learnings and patterns
 
 **Key Findings:**
+
 - Authentication: 4 methods (API_KEY, SECURITY_TOKEN, INSTANCE_PRINCIPAL, RESOURCE_PRINCIPAL)
 - Service endpoint: `https://inference.generativeai.{region}.oci.oraclecloud.com`
 - Model naming: `provider.model-name-version` format
@@ -54,6 +64,7 @@ None currently - all bugs have been resolved!
 - Comprehensive error mapping required
 
 ### 1.2 OCI Provider Implementation
+
 - [x] **Setup & Configuration**
   - [x] Add OCI SDK dependency
   - [x] Create OCI config reader (support ~/.oci/config)
@@ -83,12 +94,14 @@ None currently - all bugs have been resolved!
   - [x] Network errors
 
 ### 1.3 Testing & Validation
+
 - [x] Unit tests with mocked OCI responses (created test_oci_provider.py)
 - [x] Integration tests (with real OCI if available)
 - [ ] Performance benchmarks
 - [x] Example scripts (created demo_oci.py)
 
 ### 1.4 CLI Integration
+
 - [x] **Functional CLI Entry Point**
   - [x] Interactive chat mode with model selection
   - [x] One-shot execution mode
@@ -109,28 +122,31 @@ None currently - all bugs have been resolved!
   - [x] Exit/clear commands in interactive mode
 
 ### 1.5 Versioning
+
 - [x] Version based on date/time
 - [x] Automate CI versioning and release schedule
 
 ### 1.6 Branding
+
 - [x] Project logo integration (terminal-themed design)
 - [x] Logo variants for different contexts (PNG assets)
 
 ## Phase 2: Core Provider Architecture ✅ COMPLETED (July 4, 2025)
 
 ### 2.1 Provider Interface Design
+
 - [x] Create abstract base provider class (base.py)
 - [x] Define standard methods: chat, chat_stream, list_models, get_model_info
 - [x] Implement provider registry/factory pattern
 - [x] Add provider configuration management
 
 ### 2.2 Additional Native Providers
+
 - [x] **LiteLLM Provider** (Gateway to 100+ providers)
   - [x] Basic chat completion
   - [x] Streaming support
   - [x] Model discovery
   - [x] Error handling and retries
-  
 - [x] **Ollama Provider** (Local models)
   - [x] Direct API integration (no LiteLLM dependency)
   - [x] Model management (list, pull, delete)
@@ -138,6 +154,7 @@ None currently - all bugs have been resolved!
   - [x] Health checks and auto-discovery
 
 ### 2.3 Unified Chat Interface
+
 - [x] Create core chat engine
 - [x] Message history management
 - [x] System prompt handling
@@ -146,7 +163,8 @@ None currently - all bugs have been resolved!
 
 ## Phase 3: Enhanced CLI Experience ✅ COMPLETED (July 4, 2025)
 
-### 3.1 Interactive Shell ✅ 
+### 3.1 Interactive Shell ✅
+
 - [x] Rich prompt with syntax highlighting using prompt-toolkit
 - [x] Multi-line input support (use \ at end of line)
 - [x] Command history and search (with file-based persistence)
@@ -154,7 +172,8 @@ None currently - all bugs have been resolved!
 - [x] Keyboard shortcuts (Ctrl+C, Ctrl+D, arrow keys)
 - [x] Clean interrupt handling during AI responses
 
-### 3.2 Slash Commands ✅ 
+### 3.2 Slash Commands ✅
+
 - [x] `/help` (`/h`, `/?`) - Show available commands and keyboard shortcuts
 - [x] `/model` (`/m`) - Interactive model selection with search
 - [x] `/provider` (`/p`) - Switch providers (OCI GenAI supported)
@@ -162,7 +181,8 @@ None currently - all bugs have been resolved!
 - [x] `/clear` (`/cls`) - Clear conversation (placeholder)
 - [x] `/exit` (`/quit`, `/q`) - Exit application
 
-### 3.3 Developer Modes ✅ 
+### 3.3 Developer Modes ✅
+
 - [x] **General Mode**: Default conversational AI assistant
 - [x] **Code Mode**: Optimized for writing new code with best practices
 - [x] **Debug Mode**: Focus on error analysis and debugging assistance
@@ -172,6 +192,7 @@ None currently - all bugs have been resolved!
 - [x] **Plan Mode**: Architecture planning and system design
 
 ### 3.4 Additional Features Implemented
+
 - [x] Interactive vs Basic mode selection based on TTY detection
 - [x] Model deduplication in selection UI
 - [x] Multi-level tab completion for slash commands
@@ -181,12 +202,14 @@ None currently - all bugs have been resolved!
 ## Phase 4: Session Management
 
 **⚠️ PARALLEL DEVELOPMENT NOTE**: Phase 4 and 5 are being developed in parallel on separate branches. To minimize merge conflicts:
+
 - Phase 4 branch: `feature/session-management` (focuses on persistence layer)
 - Phase 5 branch: `feature/mcp-tools` (focuses on tool execution)
 - Integration points: Session schema will need `tool_invocations` table from Phase 5
 - Merge strategy: Phase 4 merges first, then Phase 5 rebases and adds tool logging
 
 ### 4.1 Persistence Layer ✅ COMPLETED
+
 - [x] SQLite database for sessions (stored in `~/.cache/coda/sessions.db`)
 - [x] Message storage with metadata and provider/model tracking
 - [x] Full-text search across sessions with FTS5
@@ -195,6 +218,7 @@ None currently - all bugs have been resolved!
 - [x] Tags and session metadata support
 
 ### 4.2 Session Commands ✅ COMPLETED
+
 - [x] `/session` (`/s`) - Save/load/branch conversations
   - [x] `save [name]` - Save current conversation with optional name
   - [x] `load <id|name>` - Load a saved session by ID or name
@@ -210,12 +234,14 @@ None currently - all bugs have been resolved!
   - [x] `html` - Export as HTML with syntax highlighting
 
 ### 4.3 Context Management ✅ COMPLETED
+
 - [x] Intelligent context windowing based on model limits
 - [x] Context optimization with token counting
 - [x] Message prioritization (system > recent > historical)
 - [x] Conversation memory preserved across save/load cycles
 
 ### 4.4 Testing Infrastructure ✅ COMPLETED
+
 - [x] MockProvider for deterministic, offline testing
 - [x] Comprehensive test coverage (51 conversation tests)
 - [x] Tests for all CLI commands and developer modes
@@ -223,35 +249,31 @@ None currently - all bugs have been resolved!
 - [x] Edge case and error handling tests
 
 ### 4.5 Automatic Session Saving (Enhancement) 🚧 DEFERRED
+
 - [x] **Auto-Save by Default** ✅ COMPLETED
   - [x] Automatic session creation on first message
   - [x] Anonymous sessions with timestamp names (e.g., `auto-20250105-143022`)
   - [x] Zero configuration required - just start chatting
   - [🔄] Async saves to avoid blocking chat flow (DEFERRED)
-  
 - [🔄] **Rolling Window Management** (DEFERRED)
   - [🔄] Keep last 1000 messages per session
   - [🔄] Archive older messages to linked archive sessions
   - [🔄] Maintain parent-child relationships for full history
   - [🔄] Transparent access to archived content via search
-  
 - [x] **User Control Options** ✅ COMPLETED
   - [x] `/session rename` - Rename auto-created sessions
   - [x] `--no-save` CLI flag - Opt out for sensitive conversations
   - [x] Config option: `auto_save_enabled = true/false` (uses existing `autosave`)
   - [x] Bulk delete options for privacy (`/session delete-all [--auto-only]`)
-  
 - [x] **Additional Features** ✅ COMPLETED
   - [x] `/session last` - Load most recent session
   - [x] `--resume` CLI flag - Auto-load last session on startup
-  
 - [x] **Performance Optimizations** ✅ PARTIALLY COMPLETED
   - [🔄] Batch message inserts for efficiency (DEFERRED)
   - [🔄] Background save queue to prevent UI blocking (DEFERRED)
   - [x] Index on created_at for fast queries
   - [x] Additional indexes for name, accessed_at, parent_id, and tags
   - [🔄] Lazy loading of historical messages (DEFERRED)
-  
 - [x] **Privacy & Disclosure** ✅ MOSTLY COMPLETED
   - [x] Clear notification about auto-save on first run
   - [x] Easy bulk delete commands (`/session delete-all`)
@@ -265,9 +287,63 @@ None currently - all bugs have been resolved!
   - [x] Updated help display to show implemented commands
   - [ ] Full command initialization from registry (lower priority)
 
+### 4.6 Code Quality Refactoring (NEW) 🚧 PENDING
+
+**Branch Strategy**: Create `feature/code-quality-refactor` from current feature branch
+
+#### High Priority - Eliminate Hardcoded Values
+
+- [ ] **Create `coda/constants.py` module** for centralized configuration
+  - [ ] Path constants (`.coda`, `.config`, `sessions.db`, etc.)
+  - [ ] Default query limits (50, 100, 1000)
+  - [ ] File extensions and formats (`.toml`, `.txt`, etc.)
+  - [ ] Environment variable names
+  - [ ] Database table and schema constants
+  - [ ] Cache durations (24-hour model cache)
+  - [ ] Default temperature and context limits
+
+- [ ] **Create theme/styling configuration**
+  - [ ] Extract all hardcoded colors from CLI modules
+  - [ ] Create theme configuration system
+  - [ ] Support for theme switching via `/theme` command
+  - [ ] Consolidate prompt-toolkit styles
+
+#### Medium Priority - Code Structure
+
+- [ ] **Remove duplicate `commands_config.yaml`**
+  - [ ] CommandRegistry in Python supersedes YAML
+  - [ ] Delete unused YAML file
+  - [ ] Update any references
+
+- [ ] **Consolidate interactive CLI modules**
+  - [ ] Merge `interactive.py` and `interactive_cli.py`
+  - [ ] Remove duplicate command handling logic
+  - [ ] Use InteractiveCLI class consistently
+
+- [ ] **Remove unnecessary wrapper methods**
+  - [ ] Direct calls to shared functions instead of wrappers
+  - [ ] Eliminate `get_system_prompt()` wrappers
+
+#### Configuration Updates
+
+- [ ] **Update configuration module**
+  - [ ] Use constants instead of hardcoded values
+  - [ ] Make session limits configurable
+  - [ ] Add theme configuration support
+  - [ ] Document all configuration options
+
+#### Testing
+
+- [ ] Update tests to use constants
+- [ ] Ensure no hardcoded values in test files
+- [ ] Add tests for theme configuration
+
+**Timeline**: Complete before merging Phase 5
+
 ## Phase 5: Tool Integration (MCP)
 
 **⚠️ PARALLEL DEVELOPMENT NOTE**: Being developed in parallel with Phase 4. Key considerations:
+
 - Work on branch: `feature/mcp-tools`
 - Mock the session storage API during development
 - Plan for adding `tool_invocations` to session schema after merge
@@ -275,6 +351,7 @@ None currently - all bugs have been resolved!
 - Focus on creating new files: `tools/`, `mcp/` directories
 
 ### 5.1 Core Tools
+
 - [ ] File operations (read, write, edit)
 - [ ] Shell command execution
 - [ ] Web search and fetch
@@ -282,6 +359,7 @@ None currently - all bugs have been resolved!
 - [ ] **Tool Result Storage**: Design format for session integration
 
 ### 5.2 Tool Commands
+
 - [ ] `/tools` (`/t`) - Manage MCP tools
   - [ ] `list` - List available MCP tools
   - [ ] `enable` - Enable specific tools
@@ -290,6 +368,7 @@ None currently - all bugs have been resolved!
   - [ ] `status` - Show tool status
 
 ### 5.3 MCP Protocol
+
 - [ ] MCP server implementation
 - [ ] Tool discovery and registration
 - [ ] Permission management
@@ -298,17 +377,19 @@ None currently - all bugs have been resolved!
 ## Phase 6: Advanced Features
 
 ### 6.1 Multi-Modal Support
+
 - [ ] Image understanding (for providers that support it)
 - [ ] Code screenshot analysis
 - [ ] Important documents to support
-    - [ ] PDF support
-    - [ ] Microsoft Word doc support
-    - [ ] Microsoft Powerpoint support
-    - [ ] Microsoft Excel support
+  - [ ] PDF support
+  - [ ] Microsoft Word doc support
+  - [ ] Microsoft Powerpoint support
+  - [ ] Microsoft Excel support
 - [ ] Diagram generation
 - [ ] Use [diagram-renderer](https://github.com/djvolz/diagram-renderer)
 
 ### 6.2 Project Intelligence
+
 - [ ] Automatic project type detection
 - [ ] Specifically handle multiple version control systems beyond just git. Very important.
 - [ ] Language-specific optimizations
@@ -318,6 +399,7 @@ None currently - all bugs have been resolved!
 - [ ] Multi-project management (handle multiple projects simultaneously)
 
 ### 6.3 UI Customization
+
 - [ ] `/theme` - Change UI theme
   - [ ] `default` - Default color scheme
   - [ ] `dark` - Dark mode optimized
@@ -331,7 +413,8 @@ None currently - all bugs have been resolved!
   - [ ] Toggle between raw and formatted view
   - [ ] Preserve terminal scrollback while rendering
 
-### 6.4 Collaboration Features
+### 6.4 Collaboration Features (DEFERRED)
+
 - [ ] Session sharing via URLs
 - [ ] Team knowledge base
 - [ ] Shared prompt library
@@ -339,6 +422,7 @@ None currently - all bugs have been resolved!
 ## Phase 7: Web UI (Streamlit)
 
 ### 7.1 Dashboard
+
 - [ ] Provider status and health
 - [ ] Model selection and comparison
 - [ ] Usage statistics
@@ -346,6 +430,7 @@ None currently - all bugs have been resolved!
 - [ ] Cost tracking (for paid providers)
 
 ### 7.2 Chat Interface
+
 - [ ] Web-based chat UI
 - [ ] Code highlighting
 - [ ] File upload/download
@@ -354,6 +439,7 @@ None currently - all bugs have been resolved!
 ## Phase 8: Vector Embedding & Semantic Search
 
 ### 8.1 Embedding Providers
+
 - [ ] **OCI Embedding Service Integration**
   - [ ] OCI GenAI embedding models (multilingual-e5, cohere-embed-multilingual-v3.0)
   - [ ] Batch embedding support for large datasets
@@ -367,6 +453,7 @@ None currently - all bugs have been resolved!
   - [ ] Custom embedding model support
 
 ### 8.2 Vector Storage Backends
+
 - [ ] **Oracle Vector Database**
   - [ ] Oracle Database 23ai vector support
   - [ ] Vector similarity search queries
@@ -385,6 +472,7 @@ None currently - all bugs have been resolved!
   - [ ] Local SQLite vector extension
 
 ### 8.3 Semantic Search Features
+
 - [ ] **Content Indexing**
   - [ ] Code file embedding and indexing
   - [ ] Documentation and comment extraction
@@ -406,6 +494,7 @@ None currently - all bugs have been resolved!
 ## Phase 9: Codebase Intelligence
 
 ### 9.1 Repository Analysis
+
 - [ ] **Repo Mapping**
   - [ ] Repo mapping like [aider](https://aider.chat/docs/repomap.html)
   - [ ] Tree-sitter integration using [aider ts implementation](https://github.com/Aider-AI/aider/tree/main/aider/queries)
@@ -414,6 +503,7 @@ None currently - all bugs have been resolved!
   - [ ] Dependency graph generation
 
 ### 9.2 Context Management
+
 - [ ] **Intelligent Context Handling**
   - [ ] Automatic conversation compacting for long sessions
   - [ ] Smart context window management based on codebase structure
@@ -421,6 +511,7 @@ None currently - all bugs have been resolved!
   - [ ] Token usage optimization with semantic understanding
 
 ### 9.3 Code Understanding
+
 - [ ] **Semantic Analysis**
   - [ ] Function and class relationship mapping
   - [ ] Call graph generation
@@ -437,18 +528,17 @@ None currently - all bugs have been resolved!
 ## Phase 10: Help Mode Integration
 
 ### 10.1 Wiki-Based Help System
+
 - [ ] **Wiki Integration**
   - [ ] GitHub wiki API client for fetching content from https://github.com/djvolz/coda-code-assistant/wiki/
   - [ ] Local caching of wiki pages for offline access
   - [ ] Automatic wiki content updates and sync
   - [ ] Search functionality across wiki content (enhanced by semantic search)
-  
 - [ ] **Help Commands**
   - [ ] `/help wiki` - Interactive wiki search and navigation
   - [ ] `/help search <query>` - Search wiki for specific topics
   - [ ] `/help topics` - List available help topics from wiki
   - [ ] `/help refresh` - Force refresh of cached wiki content
-  
 - [ ] **Context-Aware Help**
   - [ ] Analyze user questions to suggest relevant wiki pages
   - [ ] Auto-suggest help topics based on current conversation context
@@ -462,6 +552,7 @@ None currently - all bugs have been resolved!
   - [ ] Breadcrumb navigation for wiki sections
 
 ### 10.2 Implementation Details
+
 - [ ] **Wiki Content Processing**
   - [ ] Parse GitHub wiki markdown format
   - [ ] Extract and index searchable content
@@ -477,6 +568,7 @@ None currently - all bugs have been resolved!
 ## Phase 11: Observability & Performance
 
 ### 11.1 Monitoring & Telemetry
+
 - [ ] **OpenTelemetry Integration**
   - [ ] Metrics for daily active users and session statistics
   - [ ] Performance monitoring (response times, token usage)
@@ -492,6 +584,7 @@ None currently - all bugs have been resolved!
 ## Phase 12: DevOps & Automation
 
 ### 12.1 Deployment & Distribution
+
 - [ ] **Containerization**
   - [ ] Containerize coda with ollama bundled by default
   - [ ] Docker compose setup for development
@@ -499,16 +592,17 @@ None currently - all bugs have been resolved!
   - [ ] Container optimization for size and performance
 
 ### 12.2 Development Workflow
+
 - [ ] **Version Control Integration**
   - [ ] Wiki update checker and notification system
   - [ ] Changelog generator (VCS-agnostic, hash-to-hash)
   - [ ] Automated changelog detection from commits
   - [ ] Git workflow optimization tools
 
-
 ## Technical Decisions
 
 ### Architecture
+
 - **Async First**: Use asyncio throughout for better performance
 - **Plugin System**: Providers and tools as plugins
 - ** Modularity **: We want to make this code as modular as possible so other projects can use self-contained pieces as APIs (without the need for our UI)
@@ -516,18 +610,21 @@ None currently - all bugs have been resolved!
 - **Testing**: Comprehensive test suite with mocked providers
 
 ### Dependencies
+
 - **Core**: litellm, httpx, pydantic
 - **CLI**: rich, prompt-toolkit, click
 - **Storage**: sqlalchemy, aiosqlite
 - **Web**: streamlit (optional)
 
 ### Configuration
+
 - Follow XDG Base Directory spec
 - TOML configuration files
 - Environment variable overrides
 - Per-project settings
 
 ### Versioning & Release Strategy
+
 - Date-based versioning: `year.month.day.HHMM`
 - Automated releases via conventional commits
 - Continuous delivery on main branch
@@ -536,23 +633,27 @@ None currently - all bugs have been resolved!
 ## Development Workflow
 
 ### Branch Strategy & Release Pipeline
+
 - `main`: Stable releases (production-ready)
 - `develop`: Integration branch (staging)
 - `feature/*`: Feature branches (development)
 - `fix/*`: Bug fixes
 
 **Future Enhancement**: Implement dev → staging → stable pipeline
+
 - Automated testing gates between stages
 - Staging environment for pre-release validation
 - Stable releases with semantic versioning
 
 ### Testing Strategy
+
 - Unit tests for each provider
 - Integration tests for CLI commands
 - Mock providers for testing
 - Performance benchmarks
 
 ### Documentation
+
 - API documentation (Sphinx)
 - User guide with examples
 - Provider setup guides
@@ -561,6 +662,7 @@ None currently - all bugs have been resolved!
 ## Milestones
 
 ### 2025.7.2 - OCI Foundation ✅ COMPLETED
+
 - ✅ Native OCI GenAI provider implementation
 - ✅ Basic chat completion support
 - ✅ Streaming responses
@@ -569,6 +671,7 @@ None currently - all bugs have been resolved!
 - ✅ Configuration file support
 
 ### 2025.7.3 - Versioning & Release Automation ✅ COMPLETED
+
 - ✅ Date-based versioning (year.month.day.HHMM format)
 - ✅ Automated release workflow with GitHub Actions
 - ✅ Conventional commits support
@@ -579,7 +682,9 @@ None currently - all bugs have been resolved!
 - ✅ Git commit message template
 
 ### 2025.7.4 - Provider Architecture & Enhanced CLI ✅ COMPLETED
+
 **Phase 2 - Provider Architecture**:
+
 - ✅ Abstract provider interface with BaseProvider class
 - ✅ Provider registry and factory pattern
 - ✅ LiteLLM integration (100+ providers)
@@ -588,6 +693,7 @@ None currently - all bugs have been resolved!
 - ✅ Multi-source config priority (CLI > env > project > user > defaults)
 
 **Phase 3 - Enhanced CLI Experience**:
+
 - ✅ Interactive shell with prompt-toolkit
 - ✅ Slash commands (/help, /model, /mode, etc.)
 - ✅ 7 Developer modes (general, code, debug, explain, review, refactor, plan)
@@ -596,6 +702,7 @@ None currently - all bugs have been resolved!
 - ✅ Improved error handling and user experience
 
 **Integration Notes**:
+
 - ✅ Successfully merged concurrent Phase 2 & 3 development
 - ✅ Resolved conflicts in 4 files during integration
 - ✅ All Phase 3 CLI features work with Phase 2 provider system
@@ -604,7 +711,9 @@ None currently - all bugs have been resolved!
 - ✅ Comprehensive test coverage for slash commands
 
 ### 2025.7.5 - Session Management ✅ COMPLETED (Phase 4)
+
 **Session Infrastructure**:
+
 - ✅ SQLAlchemy-based session database with automatic migrations
 - ✅ Full session management system (create, save, load, branch, delete)
 - ✅ Message persistence with provider/model metadata tracking
@@ -613,6 +722,7 @@ None currently - all bugs have been resolved!
 - ✅ Export functionality (JSON, Markdown, TXT, HTML)
 
 **MockProvider Implementation**:
+
 - ✅ Deterministic mock provider for offline testing
 - ✅ Context-aware responses for Python, decorators, JavaScript
 - ✅ Conversation memory tracking ("what were we discussing?")
@@ -620,6 +730,7 @@ None currently - all bugs have been resolved!
 - ✅ Full streaming support
 
 **Comprehensive Testing**:
+
 - ✅ 51 tests for MockProvider conversations
 - ✅ Tests for all 7 developer modes
 - ✅ Tests for both mock models (echo/smart)
@@ -628,13 +739,14 @@ None currently - all bugs have been resolved!
 - ✅ Edge case and error handling coverage
 
 **CLI Integration**:
+
 - ✅ /session command with 7 subcommands
 - ✅ /export command with 4 formats
 - ✅ Seamless integration with existing interactive shell
 - ✅ Conversation continuity across save/load cycles
 
-
 ### 2025.7.12 - Tool Integration / MCP (Target: July 12)
+
 - MCP server implementation
 - Core tools (file ops, shell, web search, git)
 - Tool commands (/tools list/enable/disable/config/status)
@@ -642,6 +754,7 @@ None currently - all bugs have been resolved!
 - Custom tool SDK
 
 ### 2025.7.15 - Advanced Features (Target: July 15)
+
 - Multi-modal support (image understanding)
 - Document support (PDF, Word, PowerPoint, Excel)
 - Enhanced response rendering (live markdown)
@@ -660,20 +773,17 @@ None currently - all bugs have been resolved!
    - Complete implementation of `/session` and `/export` commands
    - MockProvider for deterministic testing
    - 100+ tests covering all session functionality
-   
 2. **Next - Phase 5**: Tool Integration (MCP) (Target: July 12)
    - Core tools for file operations
    - Shell command execution
    - Web search and fetch capabilities
    - Git operations
    - Implementation of `/tools` command
-   
 3. **Following - Phase 6**: Advanced Features (Target: July 15)
    - Multi-modal support (image understanding)
    - Code screenshot analysis
    - Document support (PDF, Word, PowerPoint, Excel)
    - Enhanced response rendering with live markdown
-   
 4. **Future Phases**:
    - Phase 7: Web UI with Streamlit
    - Phase 8: Additional features (containerization, repo mapping, telemetry)
@@ -689,7 +799,8 @@ None currently - all bugs have been resolved!
 ## Completed Items
 
 ### Project Branding (2025.7.3)
-- [x] Extract logo assets from `/tmp/logo.html` 
+
+- [x] Extract logo assets from `/tmp/logo.html`
 - [x] Create `assets/logos/` directory structure
 - [x] Generate logo files in multiple formats:
   - [x] SVG (scalable, main format)
@@ -699,17 +810,19 @@ None currently - all bugs have been resolved!
   - [x] README.md header
   - [x] Add all three logo variants from original design
   - [ ] Documentation (when created)
-  - [ ] Future web UI  
+  - [ ] Future web UI
   - [ ] GitHub social preview
 - [x] Add logo usage guidelines to documentation
 
 ### Bugs Fixed (2025.7.3)
+
 - [x] **Fix CI pipeline** - Resolved version extraction error by using portable grep syntax instead of -P flag
 - [x] **Fix uv sync bug on other machine** - Identified as VPN/proxy interference, added general troubleshooting guide
 - [x] **Add Python 3.13 support** - Updated test matrices, Black configuration, and documentation
 - [x] **Remove dedicated flag for compartment-id** - Removed provider-specific CLI flag; now uses env var or config file
 
 ### Phase 2: Provider Architecture (2025.7.4)
+
 - [x] **Abstract Provider Interface** - Created BaseProvider ABC with standard methods
 - [x] **Provider Registry/Factory** - Dynamic provider registration and instantiation
 - [x] **Configuration Management** - Multi-source config with priority hierarchy

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ Build a multi-provider, CLI-focused code assistant that provides a unified inter
 - **Phase 3**: Enhanced CLI Experience (interactive shell, slash commands, developer modes)
 
 ✅ **Phase 4**: Session Management - COMPLETED (July 5, 2025) | 🚧 Enhancement 4.5 Pending
-- SQLite persistence layer with automatic migrations
+- SQLite persistence layer (stored in ~/.cache/coda/sessions.db)
 - Session commands (/session save/load/list/branch/delete/info/search)
 - Export commands (/export json/markdown/txt/html)
 - Full-text search across sessions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -258,6 +258,13 @@ None currently - all bugs have been resolved!
   - [ ] Optional encryption for stored sessions
   - [x] Respect XDG data directories (already implemented)
 
+- [x] **Command System Refactoring** ✅ MOSTLY COMPLETED
+  - [x] Centralized CommandRegistry for single source of truth
+  - [x] Consistent autocomplete from registry definitions
+  - [x] Dynamic help text generation from registry
+  - [x] Updated help display to show implemented commands
+  - [ ] Full command initialization from registry (lower priority)
+
 ## Phase 5: Tool Integration (MCP)
 
 **⚠️ PARALLEL DEVELOPMENT NOTE**: Being developed in parallel with Phase 4. Key considerations:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,14 +10,17 @@ Build a multi-provider, CLI-focused code assistant that provides a unified inter
 - **Phase 2**: Core Provider Architecture (LiteLLM, Ollama, provider registry)
 - **Phase 3**: Enhanced CLI Experience (interactive shell, slash commands, developer modes)
 
-🚧 **Current Focus**: Phase 4 - Session Management (Target: July 10)
-- SQLite persistence layer
-- Session commands (/session save/load/list/branch/delete)
+✅ **Phase 4**: Session Management - COMPLETED (July 5, 2025)
+- SQLite persistence layer with automatic migrations
+- Session commands (/session save/load/list/branch/delete/info/search)
+- Export commands (/export json/markdown/txt/html)
 - Full-text search across sessions
-- Context management
+- Context optimization for token limits
+- MockProvider for deterministic testing
+
+🚧 **Current Focus**: Phase 5 - Tool Integration (MCP) - Target: July 12
 
 📅 **Upcoming**:
-- Phase 5: Tool Integration (MCP) - July 12
 - Phase 6: Advanced Features - July 15
 - Phase 7: Web UI (Streamlit)
 - Phase 8: Additional features
@@ -183,31 +186,41 @@ None currently - all bugs have been resolved!
 - Integration points: Session schema will need `tool_invocations` table from Phase 5
 - Merge strategy: Phase 4 merges first, then Phase 5 rebases and adds tool logging
 
-### 4.1 Persistence Layer
-- [ ] SQLite database for sessions (stored in `~/.cache/coda/sessions.db`)
-- [ ] Message storage with metadata
-- [ ] Full-text search across sessions
-- [ ] Session branching and merging
-- [ ] **API Design**: Create clear interfaces that Phase 5 can mock
+### 4.1 Persistence Layer ✅ COMPLETED
+- [x] SQLite database for sessions (stored in `~/.local/share/coda/sessions/sessions.db`)
+- [x] Message storage with metadata and provider/model tracking
+- [x] Full-text search across sessions with FTS5
+- [x] Session branching with parent-child relationships
+- [x] Automatic database migrations and backups
+- [x] Tags and session metadata support
 
-### 4.2 Session Commands
-- [ ] `/session` (`/s`) - Save/load/branch conversations
-  - [ ] `save` - Save current conversation
-  - [ ] `load` - Load a saved conversation
-  - [ ] `list` - List all saved sessions
-  - [ ] `branch` - Create a branch from current conversation
-  - [ ] `delete` - Delete a saved session
-- [ ] `/export` (`/e`) - Export conversations
-  - [ ] `markdown` - Export as Markdown file
-  - [ ] `json` - Export as JSON with metadata
-  - [ ] `txt` - Export as plain text
-  - [ ] `html` - Export as HTML with syntax highlighting
+### 4.2 Session Commands ✅ COMPLETED
+- [x] `/session` (`/s`) - Save/load/branch conversations
+  - [x] `save [name]` - Save current conversation with optional name
+  - [x] `load <id|name>` - Load a saved session by ID or name
+  - [x] `list` - List all saved sessions with metadata
+  - [x] `branch [name]` - Create a branch from current conversation
+  - [x] `delete <id|name>` - Delete a saved session with confirmation
+  - [x] `info [id]` - Show detailed session information
+  - [x] `search <query>` - Full-text search across all sessions
+- [x] `/export` (`/e`) - Export conversations
+  - [x] `json` - Export as JSON with full metadata
+  - [x] `markdown` (`md`) - Export as Markdown file
+  - [x] `txt` (`text`) - Export as plain text
+  - [x] `html` - Export as HTML with syntax highlighting
 
-### 4.3 Context Management
-- [ ] Intelligent context windowing
-- [ ] File reference tracking (@mentions)
-- [ ] Context summarization for long sessions
-- [ ] Project-aware context
+### 4.3 Context Management ✅ COMPLETED
+- [x] Intelligent context windowing based on model limits
+- [x] Context optimization with token counting
+- [x] Message prioritization (system > recent > historical)
+- [x] Conversation memory preserved across save/load cycles
+
+### 4.4 Testing Infrastructure ✅ COMPLETED
+- [x] MockProvider for deterministic, offline testing
+- [x] Comprehensive test coverage (51 conversation tests)
+- [x] Tests for all CLI commands and developer modes
+- [x] Session workflow end-to-end tests
+- [x] Edge case and error handling tests
 
 ## Phase 5: Tool Integration (MCP)
 
@@ -407,12 +420,36 @@ None currently - all bugs have been resolved!
 - ✅ Code refactoring: 220-line function split into focused helpers
 - ✅ Comprehensive test coverage for slash commands
 
-### 2025.7.10 - Session Management (Target: July 10)
-- SQLite database for sessions
-- Message persistence with metadata
-- Session commands (/session save/load/list/branch/delete)
-- Full-text search across sessions
-- Context windowing and summarization
+### 2025.7.5 - Session Management ✅ COMPLETED (Phase 4)
+**Session Infrastructure**:
+- ✅ SQLAlchemy-based session database with automatic migrations
+- ✅ Full session management system (create, save, load, branch, delete)
+- ✅ Message persistence with provider/model metadata tracking
+- ✅ Full-text search across all sessions using SQLite FTS5
+- ✅ Session branching for exploring alternate conversation paths
+- ✅ Export functionality (JSON, Markdown, TXT, HTML)
+
+**MockProvider Implementation**:
+- ✅ Deterministic mock provider for offline testing
+- ✅ Context-aware responses for Python, decorators, JavaScript
+- ✅ Conversation memory tracking ("what were we discussing?")
+- ✅ Two models: mock-echo (4K) and mock-smart (8K)
+- ✅ Full streaming support
+
+**Comprehensive Testing**:
+- ✅ 51 tests for MockProvider conversations
+- ✅ Tests for all 7 developer modes
+- ✅ Tests for both mock models (echo/smart)
+- ✅ Tests for all CLI commands
+- ✅ End-to-end session workflow tests
+- ✅ Edge case and error handling coverage
+
+**CLI Integration**:
+- ✅ /session command with 7 subcommands
+- ✅ /export command with 4 formats
+- ✅ Seamless integration with existing interactive shell
+- ✅ Conversation continuity across save/load cycles
+
 
 ### 2025.7.12 - Tool Integration / MCP (Target: July 12)
 - MCP server implementation
@@ -430,14 +467,16 @@ None currently - all bugs have been resolved!
 
 ## Next Steps
 
-**Current Status**: Phases 1, 2, and 3 are complete. Ready to begin Phase 4.
+**Current Status**: Phases 1, 2, 3, and 4 are complete. Ready to begin Phase 5.
 
-1. **Immediate Priority - Phase 4**: Session Management (Target: July 10)
-   - SQLite database for sessions
-   - Message persistence with metadata
-   - Session branching and search
-   - Full-text search across sessions
-   - Implementation of `/session` command with all subcommands
+1. **Completed - Phase 4**: Session Management ✅
+   - SQLite database with automatic migrations
+   - Message persistence with provider/model metadata
+   - Session branching with parent-child relationships
+   - Full-text search using SQLite FTS5
+   - Complete implementation of `/session` and `/export` commands
+   - MockProvider for deterministic testing
+   - 100+ tests covering all session functionality
    
 2. **Next - Phase 5**: Tool Integration (MCP) (Target: July 12)
    - Core tools for file operations

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -235,25 +235,26 @@ None currently - all bugs have been resolved!
   - [ ] Maintain parent-child relationships for full history
   - [ ] Transparent access to archived content via search
   
-- [x] **User Control Options** ✅ MOSTLY COMPLETED
+- [x] **User Control Options** ✅ COMPLETED
   - [x] `/session rename` - Rename auto-created sessions
   - [x] `--no-save` CLI flag - Opt out for sensitive conversations
   - [x] Config option: `auto_save_enabled = true/false` (uses existing `autosave`)
-  - [ ] Bulk delete options for privacy
+  - [x] Bulk delete options for privacy (`/session delete-all [--auto-only]`)
   
 - [x] **Additional Features** ✅ COMPLETED
   - [x] `/session last` - Load most recent session
   - [x] `--resume` CLI flag - Auto-load last session on startup
   
-- [ ] **Performance Optimizations**
+- [x] **Performance Optimizations** ✅ PARTIALLY COMPLETED
   - [ ] Batch message inserts for efficiency
   - [ ] Background save queue to prevent UI blocking
-  - [ ] Index on created_at for fast queries
+  - [x] Index on created_at for fast queries
+  - [x] Additional indexes for name, accessed_at, parent_id, and tags
   - [ ] Lazy loading of historical messages
   
-- [ ] **Privacy & Disclosure**
-  - [ ] Clear notification about auto-save on first run
-  - [ ] Easy bulk delete commands
+- [x] **Privacy & Disclosure** ✅ MOSTLY COMPLETED
+  - [x] Clear notification about auto-save on first run
+  - [x] Easy bulk delete commands (`/session delete-all`)
   - [ ] Optional encryption for stored sessions
   - [x] Respect XDG data directories (already implemented)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Build a multi-provider, CLI-focused code assistant that provides a unified inter
 - **Phase 2**: Core Provider Architecture (LiteLLM, Ollama, provider registry)
 - **Phase 3**: Enhanced CLI Experience (interactive shell, slash commands, developer modes)
 
-✅ **Phase 4**: Session Management - COMPLETED (July 5, 2025)
+✅ **Phase 4**: Session Management - COMPLETED (July 5, 2025) | 🚧 Enhancement 4.5 Pending
 - SQLite persistence layer with automatic migrations
 - Session commands (/session save/load/list/branch/delete/info/search)
 - Export commands (/export json/markdown/txt/html)
@@ -221,6 +221,37 @@ None currently - all bugs have been resolved!
 - [x] Tests for all CLI commands and developer modes
 - [x] Session workflow end-to-end tests
 - [x] Edge case and error handling tests
+
+### 4.5 Automatic Session Saving (Enhancement)
+- [ ] **Auto-Save by Default**
+  - [ ] Automatic session creation on first message
+  - [ ] Anonymous sessions with timestamp names (e.g., `auto-20250105-143022`)
+  - [ ] Zero configuration required - just start chatting
+  - [ ] Async saves to avoid blocking chat flow
+  
+- [ ] **Rolling Window Management** (Option 1 - Recommended)
+  - [ ] Keep last 1000 messages per session
+  - [ ] Archive older messages to linked archive sessions
+  - [ ] Maintain parent-child relationships for full history
+  - [ ] Transparent access to archived content via search
+  
+- [ ] **User Control Options**
+  - [ ] `/session rename` - Rename auto-created sessions
+  - [ ] `--no-save` CLI flag - Opt out for sensitive conversations
+  - [ ] Config option: `auto_save_enabled = true/false`
+  - [ ] Bulk delete options for privacy
+  
+- [ ] **Performance Optimizations**
+  - [ ] Batch message inserts for efficiency
+  - [ ] Background save queue to prevent UI blocking
+  - [ ] Index on created_at for fast queries
+  - [ ] Lazy loading of historical messages
+  
+- [ ] **Privacy & Disclosure**
+  - [ ] Clear notification about auto-save on first run
+  - [ ] Easy bulk delete commands
+  - [ ] Optional encryption for stored sessions
+  - [ ] Respect XDG data directories
 
 ## Phase 5: Tool Integration (MCP)
 
@@ -467,7 +498,7 @@ None currently - all bugs have been resolved!
 
 ## Next Steps
 
-**Current Status**: Phases 1, 2, 3, and 4 are complete. Ready to begin Phase 5.
+**Current Status**: Phases 1, 2, 3, and 4 are complete. Phase 4.5 (Auto-Save Enhancement) pending. Ready to begin Phase 5.
 
 1. **Completed - Phase 4**: Session Management ✅
    - SQLite database with automatic migrations

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -187,11 +187,11 @@ None currently - all bugs have been resolved!
 - Merge strategy: Phase 4 merges first, then Phase 5 rebases and adds tool logging
 
 ### 4.1 Persistence Layer ✅ COMPLETED
-- [x] SQLite database for sessions (stored in `~/.local/share/coda/sessions/sessions.db`)
+- [x] SQLite database for sessions (stored in `~/.cache/coda/sessions.db`)
 - [x] Message storage with metadata and provider/model tracking
 - [x] Full-text search across sessions with FTS5
 - [x] Session branching with parent-child relationships
-- [x] Automatic database migrations and backups
+- [x] Database initialization with schema creation
 - [x] Tags and session metadata support
 
 ### 4.2 Session Commands ✅ COMPLETED
@@ -501,7 +501,7 @@ None currently - all bugs have been resolved!
 **Current Status**: Phases 1, 2, 3, and 4 are complete. Phase 4.5 (Auto-Save Enhancement) pending. Ready to begin Phase 5.
 
 1. **Completed - Phase 4**: Session Management ✅
-   - SQLite database with automatic migrations
+   - SQLite database stored in `~/.cache/coda/sessions.db`
    - Message persistence with provider/model metadata
    - Session branching with parent-child relationships
    - Full-text search using SQLite FTS5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -222,18 +222,18 @@ None currently - all bugs have been resolved!
 - [x] Session workflow end-to-end tests
 - [x] Edge case and error handling tests
 
-### 4.5 Automatic Session Saving (Enhancement)
+### 4.5 Automatic Session Saving (Enhancement) 🚧 DEFERRED
 - [x] **Auto-Save by Default** ✅ COMPLETED
   - [x] Automatic session creation on first message
   - [x] Anonymous sessions with timestamp names (e.g., `auto-20250105-143022`)
   - [x] Zero configuration required - just start chatting
-  - [ ] Async saves to avoid blocking chat flow
+  - [🔄] Async saves to avoid blocking chat flow (DEFERRED)
   
-- [ ] **Rolling Window Management** (Option 1 - Recommended)
-  - [ ] Keep last 1000 messages per session
-  - [ ] Archive older messages to linked archive sessions
-  - [ ] Maintain parent-child relationships for full history
-  - [ ] Transparent access to archived content via search
+- [🔄] **Rolling Window Management** (DEFERRED)
+  - [🔄] Keep last 1000 messages per session
+  - [🔄] Archive older messages to linked archive sessions
+  - [🔄] Maintain parent-child relationships for full history
+  - [🔄] Transparent access to archived content via search
   
 - [x] **User Control Options** ✅ COMPLETED
   - [x] `/session rename` - Rename auto-created sessions
@@ -246,16 +246,16 @@ None currently - all bugs have been resolved!
   - [x] `--resume` CLI flag - Auto-load last session on startup
   
 - [x] **Performance Optimizations** ✅ PARTIALLY COMPLETED
-  - [ ] Batch message inserts for efficiency
-  - [ ] Background save queue to prevent UI blocking
+  - [🔄] Batch message inserts for efficiency (DEFERRED)
+  - [🔄] Background save queue to prevent UI blocking (DEFERRED)
   - [x] Index on created_at for fast queries
   - [x] Additional indexes for name, accessed_at, parent_id, and tags
-  - [ ] Lazy loading of historical messages
+  - [🔄] Lazy loading of historical messages (DEFERRED)
   
 - [x] **Privacy & Disclosure** ✅ MOSTLY COMPLETED
   - [x] Clear notification about auto-save on first run
   - [x] Easy bulk delete commands (`/session delete-all`)
-  - [ ] Optional encryption for stored sessions
+  - [🔄] Optional encryption for stored sessions (DEFERRED)
   - [x] Respect XDG data directories (already implemented)
 
 - [x] **Command System Refactoring** ✅ MOSTLY COMPLETED

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -351,19 +351,159 @@ None currently - all bugs have been resolved!
 - [ ] File upload/download
 - [ ] Session management UI
 
-## Phase 8: Other. Too be categorized
-- [ ] Opentelemetry support
-    - [ ] Metrics for daily active users and other telemetry
-- [ ] Pyroscope for debugging
-- [ ] Containerize coda and package ollama by default
-- [ ] Compacting conversation to automatically handle context
-- [ ] Repo mapping like [aider](https://aider.chat/docs/repomap.html)
-    - [ ] tree-sitter using [aider ts implementation](https://github.com/Aider-AI/aider/tree/main/aider/queries)
-        - [ ] Make sure to support documentation, function, class, struct, etc (not just ref and def like aider does)
-- [ ] Our own wiki update checker
-- [ ] Changelog detecter
-- [ ] Given any two points in the code (hash to hash but make this VCS agnostic) generate a changelog
-- [ ] Review code helper
+## Phase 8: Vector Embedding & Semantic Search
+
+### 8.1 Embedding Providers
+- [ ] **OCI Embedding Service Integration**
+  - [ ] OCI GenAI embedding models (multilingual-e5, cohere-embed-multilingual-v3.0)
+  - [ ] Batch embedding support for large datasets
+  - [ ] Authentication and configuration management
+  - [ ] Cost optimization and caching strategies
+
+- [ ] **Open Source Embedding Services**
+  - [ ] Local sentence-transformers integration
+  - [ ] Ollama embedding models support
+  - [ ] HuggingFace embedding models
+  - [ ] Custom embedding model support
+
+### 8.2 Vector Storage Backends
+- [ ] **Oracle Vector Database**
+  - [ ] Oracle Database 23ai vector support
+  - [ ] Vector similarity search queries
+  - [ ] Hybrid search (vector + traditional SQL)
+  - [ ] Connection pooling and optimization
+
+- [ ] **In-Memory FAISS**
+  - [ ] Local FAISS index management
+  - [ ] Persistent index storage
+  - [ ] Multiple index types (flat, IVF, HNSW)
+  - [ ] Memory usage optimization
+
+- [ ] **Additional Vector Stores**
+  - [ ] ChromaDB integration
+  - [ ] Pinecone support (optional)
+  - [ ] Local SQLite vector extension
+
+### 8.3 Semantic Search Features
+- [ ] **Content Indexing**
+  - [ ] Code file embedding and indexing
+  - [ ] Documentation and comment extraction
+  - [ ] Session history semantic search
+  - [ ] Multi-modal content support (code + docs)
+
+- [ ] **Search Interface**
+  - [ ] `/search semantic <query>` - Semantic similarity search
+  - [ ] `/search code <query>` - Code-specific semantic search
+  - [ ] `/search similar` - Find similar code patterns
+  - [ ] Hybrid search combining keyword and semantic
+
+- [ ] **Integration with Existing Features**
+  - [ ] Enhance session search with semantic capabilities
+  - [ ] Context-aware code suggestions
+  - [ ] Related code discovery
+  - [ ] Intelligent context selection for AI prompts
+
+## Phase 9: Codebase Intelligence
+
+### 9.1 Repository Analysis
+- [ ] **Repo Mapping**
+  - [ ] Repo mapping like [aider](https://aider.chat/docs/repomap.html)
+  - [ ] Tree-sitter integration using [aider ts implementation](https://github.com/Aider-AI/aider/tree/main/aider/queries)
+  - [ ] Support for documentation, function, class, struct, etc (beyond aider's ref/def approach)
+  - [ ] Multi-language code structure analysis
+  - [ ] Dependency graph generation
+
+### 9.2 Context Management
+- [ ] **Intelligent Context Handling**
+  - [ ] Automatic conversation compacting for long sessions
+  - [ ] Smart context window management based on codebase structure
+  - [ ] Context relevance scoring for code snippets (enhanced by semantic search)
+  - [ ] Token usage optimization with semantic understanding
+
+### 9.3 Code Understanding
+- [ ] **Semantic Analysis**
+  - [ ] Function and class relationship mapping
+  - [ ] Call graph generation
+  - [ ] Import/dependency tracking
+  - [ ] Code pattern recognition (enhanced by embeddings)
+  - [ ] Documentation extraction and indexing
+
+- [ ] **Review & Analysis Tools**
+  - [ ] AI-powered code review helper
+  - [ ] Security vulnerability detection
+  - [ ] Code quality assessment
+  - [ ] Performance bottleneck identification
+
+## Phase 10: Help Mode Integration
+
+### 10.1 Wiki-Based Help System
+- [ ] **Wiki Integration**
+  - [ ] GitHub wiki API client for fetching content from https://github.com/djvolz/coda-code-assistant/wiki/
+  - [ ] Local caching of wiki pages for offline access
+  - [ ] Automatic wiki content updates and sync
+  - [ ] Search functionality across wiki content (enhanced by semantic search)
+  
+- [ ] **Help Commands**
+  - [ ] `/help wiki` - Interactive wiki search and navigation
+  - [ ] `/help search <query>` - Search wiki for specific topics
+  - [ ] `/help topics` - List available help topics from wiki
+  - [ ] `/help refresh` - Force refresh of cached wiki content
+  
+- [ ] **Context-Aware Help**
+  - [ ] Analyze user questions to suggest relevant wiki pages
+  - [ ] Auto-suggest help topics based on current conversation context
+  - [ ] Integration with existing `/help` command to include wiki results
+  - [ ] Smart routing: CLI help vs wiki help based on query type
+
+- [ ] **Enhanced Help Experience**
+  - [ ] Formatted display of wiki content in terminal
+  - [ ] Markdown rendering for wiki pages
+  - [ ] Link resolution between wiki pages
+  - [ ] Breadcrumb navigation for wiki sections
+
+### 10.2 Implementation Details
+- [ ] **Wiki Content Processing**
+  - [ ] Parse GitHub wiki markdown format
+  - [ ] Extract and index searchable content
+  - [ ] Handle wiki page relationships and cross-references
+  - [ ] Support for code examples and syntax highlighting in help
+
+- [ ] **Caching Strategy**
+  - [ ] Store wiki content in `~/.cache/coda/wiki/`
+  - [ ] Implement cache expiration and refresh logic
+  - [ ] Offline mode fallback to cached content
+  - [ ] Delta updates for modified wiki pages
+
+## Phase 11: Observability & Performance
+
+### 11.1 Monitoring & Telemetry
+- [ ] **OpenTelemetry Integration**
+  - [ ] Metrics for daily active users and session statistics
+  - [ ] Performance monitoring (response times, token usage)
+  - [ ] Error tracking and alerting
+  - [ ] Provider health monitoring
+
+- [ ] **Debugging & Profiling**
+  - [ ] Pyroscope integration for performance profiling
+  - [ ] Debug mode enhancements
+  - [ ] Memory usage tracking
+  - [ ] Bottleneck identification
+
+## Phase 12: DevOps & Automation
+
+### 12.1 Deployment & Distribution
+- [ ] **Containerization**
+  - [ ] Containerize coda with ollama bundled by default
+  - [ ] Docker compose setup for development
+  - [ ] Multi-architecture container builds
+  - [ ] Container optimization for size and performance
+
+### 12.2 Development Workflow
+- [ ] **Version Control Integration**
+  - [ ] Wiki update checker and notification system
+  - [ ] Changelog generator (VCS-agnostic, hash-to-hash)
+  - [ ] Automated changelog detection from commits
+  - [ ] Git workflow optimization tools
 
 
 ## Technical Decisions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,10 +223,10 @@ None currently - all bugs have been resolved!
 - [x] Edge case and error handling tests
 
 ### 4.5 Automatic Session Saving (Enhancement)
-- [ ] **Auto-Save by Default**
-  - [ ] Automatic session creation on first message
-  - [ ] Anonymous sessions with timestamp names (e.g., `auto-20250105-143022`)
-  - [ ] Zero configuration required - just start chatting
+- [x] **Auto-Save by Default** ✅ COMPLETED
+  - [x] Automatic session creation on first message
+  - [x] Anonymous sessions with timestamp names (e.g., `auto-20250105-143022`)
+  - [x] Zero configuration required - just start chatting
   - [ ] Async saves to avoid blocking chat flow
   
 - [ ] **Rolling Window Management** (Option 1 - Recommended)
@@ -235,11 +235,15 @@ None currently - all bugs have been resolved!
   - [ ] Maintain parent-child relationships for full history
   - [ ] Transparent access to archived content via search
   
-- [ ] **User Control Options**
-  - [ ] `/session rename` - Rename auto-created sessions
-  - [ ] `--no-save` CLI flag - Opt out for sensitive conversations
-  - [ ] Config option: `auto_save_enabled = true/false`
+- [x] **User Control Options** ✅ MOSTLY COMPLETED
+  - [x] `/session rename` - Rename auto-created sessions
+  - [x] `--no-save` CLI flag - Opt out for sensitive conversations
+  - [x] Config option: `auto_save_enabled = true/false` (uses existing `autosave`)
   - [ ] Bulk delete options for privacy
+  
+- [x] **Additional Features** ✅ COMPLETED
+  - [x] `/session last` - Load most recent session
+  - [x] `--resume` CLI flag - Auto-load last session on startup
   
 - [ ] **Performance Optimizations**
   - [ ] Batch message inserts for efficiency
@@ -251,7 +255,7 @@ None currently - all bugs have been resolved!
   - [ ] Clear notification about auto-save on first run
   - [ ] Easy bulk delete commands
   - [ ] Optional encryption for stored sessions
-  - [ ] Respect XDG data directories
+  - [x] Respect XDG data directories (already implemented)
 
 ## Phase 5: Tool Integration (MCP)
 

--- a/coda/cli/basic_commands.py
+++ b/coda/cli/basic_commands.py
@@ -26,22 +26,30 @@ class BasicCommandProcessor(CommandHandler):
         cmd = parts[0].lower()
         args = parts[1] if len(parts) > 1 else ""
 
-        # Map commands to handlers
-        commands = {
+        # Build command map from registry
+        from coda.cli.command_registry import CommandRegistry
+        
+        # Map command names to their handlers
+        handler_map = {
             "help": lambda: self.show_help(),
-            "h": lambda: self.show_help(),
-            "?": lambda: self.show_help(),
             "model": lambda: self.switch_model(args),
-            "m": lambda: self.switch_model(args),
             "provider": lambda: self.show_provider_info(args),
-            "p": lambda: self.show_provider_info(args),
             "mode": lambda: self.switch_mode(args),
             "clear": lambda: self.clear_conversation(),
-            "cls": lambda: self.clear_conversation(),
             "exit": lambda: self.exit_application(),
-            "quit": lambda: self.exit_application(),
-            "q": lambda: self.exit_application(),
+            # Note: session, export, theme, tools not supported in basic mode
+            # They are interactive-only features
         }
+        
+        # Build commands dict from registry
+        commands = {}
+        for cmd_def in CommandRegistry.COMMANDS:
+            if cmd_def.name in handler_map:
+                # Add main command
+                commands[cmd_def.name] = handler_map[cmd_def.name]
+                # Add aliases
+                for alias in cmd_def.aliases:
+                    commands[alias] = handler_map[cmd_def.name]
 
         if cmd in commands:
             result = commands[cmd]()

--- a/coda/cli/command_registry.py
+++ b/coda/cli/command_registry.py
@@ -181,6 +181,88 @@ class CommandRegistry:
         ),
     ]
     
+    # Provider options
+    PROVIDER_OPTIONS = [
+        CommandDefinition(
+            name="oci_genai",
+            description="Oracle Cloud Infrastructure GenAI",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="ollama",
+            description="Local models via Ollama",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="openai",
+            description="OpenAI GPT models (coming soon)",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="litellm",
+            description="100+ providers via LiteLLM",
+            type=CommandType.OPTION
+        ),
+    ]
+    
+    # Theme options
+    THEME_OPTIONS = [
+        CommandDefinition(
+            name="default",
+            description="Default color scheme",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="dark",
+            description="Dark mode optimized",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="light",
+            description="Light terminal theme",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="minimal",
+            description="Minimal colors",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="vibrant",
+            description="High contrast colors",
+            type=CommandType.OPTION
+        ),
+    ]
+    
+    # Tools subcommands
+    TOOLS_SUBCOMMANDS = [
+        CommandDefinition(
+            name="list",
+            description="List available MCP tools",
+            type=CommandType.SUBCOMMAND
+        ),
+        CommandDefinition(
+            name="enable",
+            description="Enable specific tools",
+            type=CommandType.SUBCOMMAND
+        ),
+        CommandDefinition(
+            name="disable",
+            description="Disable specific tools",
+            type=CommandType.SUBCOMMAND
+        ),
+        CommandDefinition(
+            name="config",
+            description="Configure tool settings",
+            type=CommandType.SUBCOMMAND
+        ),
+        CommandDefinition(
+            name="status",
+            description="Show tool status",
+            type=CommandType.SUBCOMMAND
+        ),
+    ]
+    
     # Main commands
     COMMANDS = [
         CommandDefinition(
@@ -211,6 +293,7 @@ class CommandRegistry:
             name="provider",
             description="Switch provider",
             aliases=["p"],
+            subcommands=PROVIDER_OPTIONS,
             examples=["/provider", "/provider ollama"]
         ),
         CommandDefinition(
@@ -236,12 +319,14 @@ class CommandRegistry:
         CommandDefinition(
             name="theme",
             description="Change UI theme",
+            subcommands=THEME_OPTIONS,
             examples=["/theme", "/theme dark"]
         ),
         CommandDefinition(
             name="tools",
             description="Manage MCP tools",
             aliases=["t"],
+            subcommands=TOOLS_SUBCOMMANDS,
             examples=["/tools", "/tools list"]
         ),
     ]

--- a/coda/cli/command_registry.py
+++ b/coda/cli/command_registry.py
@@ -233,6 +233,17 @@ class CommandRegistry:
             subcommands=EXPORT_SUBCOMMANDS,
             examples=["/export json", "/export markdown", "/e html"]
         ),
+        CommandDefinition(
+            name="theme",
+            description="Change UI theme",
+            examples=["/theme", "/theme dark"]
+        ),
+        CommandDefinition(
+            name="tools",
+            description="Manage MCP tools",
+            aliases=["t"],
+            examples=["/tools", "/tools list"]
+        ),
     ]
     
     @classmethod
@@ -255,7 +266,7 @@ class CommandRegistry:
         return options
     
     @classmethod
-    def get_command_help(cls, command_name: Optional[str] = None) -> str:
+    def get_command_help(cls, command_name: Optional[str] = None, mode: str = "") -> str:
         """Get formatted help text for a command or all commands."""
         if command_name:
             cmd = cls.get_command(command_name)
@@ -283,7 +294,8 @@ class CommandRegistry:
             return help_text
         else:
             # Return help for all commands
-            help_text = "[bold]Available Commands:[/bold]\n\n"
+            mode_suffix = f" ({mode})" if mode else ""
+            help_text = f"[bold]Available Commands{mode_suffix}:[/bold]\n\n"
             for cmd in cls.COMMANDS:
                 help_text += f"[cyan]/{cmd.name}[/cyan]"
                 if cmd.aliases:

--- a/coda/cli/command_registry.py
+++ b/coda/cli/command_registry.py
@@ -1,0 +1,292 @@
+"""Centralized command registry for CLI commands and subcommands."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+from enum import Enum
+
+
+class CommandType(Enum):
+    """Type of command or subcommand."""
+    MAIN = "main"
+    SUBCOMMAND = "subcommand"
+    OPTION = "option"
+
+
+@dataclass
+class CommandDefinition:
+    """Definition of a command or subcommand."""
+    name: str
+    description: str
+    aliases: List[str] = field(default_factory=list)
+    subcommands: List['CommandDefinition'] = field(default_factory=list)
+    examples: List[str] = field(default_factory=list)
+    type: CommandType = CommandType.MAIN
+    
+    def get_all_names(self) -> List[str]:
+        """Get all names including aliases."""
+        return [self.name] + self.aliases
+    
+    def get_subcommand(self, name: str) -> Optional['CommandDefinition']:
+        """Get subcommand by name or alias."""
+        for sub in self.subcommands:
+            if name in sub.get_all_names():
+                return sub
+        return None
+    
+    def to_autocomplete_tuple(self) -> tuple[str, str]:
+        """Convert to tuple format for autocomplete."""
+        return (self.name, self.description)
+
+
+class CommandRegistry:
+    """Registry of all CLI commands."""
+    
+    # Session subcommands
+    SESSION_SUBCOMMANDS = [
+        CommandDefinition(
+            name="save",
+            description="Save current conversation",
+            aliases=["s"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session save", "/session save my_session"]
+        ),
+        CommandDefinition(
+            name="load",
+            description="Load a saved conversation",
+            aliases=["l"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session load my_session", "/session load abc123"]
+        ),
+        CommandDefinition(
+            name="last",
+            description="Load the most recent session",
+            type=CommandType.SUBCOMMAND,
+            examples=["/session last"]
+        ),
+        CommandDefinition(
+            name="list",
+            description="List all saved sessions",
+            aliases=["ls"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session list"]
+        ),
+        CommandDefinition(
+            name="branch",
+            description="Create a branch from current conversation",
+            aliases=["b"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session branch", "/session branch new_branch"]
+        ),
+        CommandDefinition(
+            name="delete",
+            description="Delete a saved session",
+            aliases=["d", "rm"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session delete my_session", "/session delete abc123"]
+        ),
+        CommandDefinition(
+            name="delete-all",
+            description="Delete all sessions (use --auto-only for just auto-saved)",
+            type=CommandType.SUBCOMMAND,
+            examples=["/session delete-all", "/session delete-all --auto-only"]
+        ),
+        CommandDefinition(
+            name="rename",
+            description="Rename a session",
+            aliases=["r"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session rename new_name", "/session rename abc123 new_name"]
+        ),
+        CommandDefinition(
+            name="info",
+            description="Show session details",
+            aliases=["i"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/session info", "/session info abc123"]
+        ),
+        CommandDefinition(
+            name="search",
+            description="Search sessions",
+            type=CommandType.SUBCOMMAND,
+            examples=["/session search python", "/session search 'error handling'"]
+        ),
+    ]
+    
+    # Export subcommands
+    EXPORT_SUBCOMMANDS = [
+        CommandDefinition(
+            name="json",
+            description="Export as JSON",
+            type=CommandType.SUBCOMMAND,
+            examples=["/export json", "/export json my_session"]
+        ),
+        CommandDefinition(
+            name="markdown",
+            description="Export as Markdown",
+            aliases=["md"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/export markdown", "/export md my_session"]
+        ),
+        CommandDefinition(
+            name="txt",
+            description="Export as plain text",
+            aliases=["text"],
+            type=CommandType.SUBCOMMAND,
+            examples=["/export txt", "/export text my_session"]
+        ),
+        CommandDefinition(
+            name="html",
+            description="Export as HTML",
+            type=CommandType.SUBCOMMAND,
+            examples=["/export html", "/export html my_session"]
+        ),
+    ]
+    
+    # Mode options
+    MODE_OPTIONS = [
+        CommandDefinition(
+            name="general",
+            description="General conversational mode",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="code",
+            description="Code writing mode",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="debug",
+            description="Debugging mode",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="explain",
+            description="Code explanation mode",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="review",
+            description="Code review mode",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="refactor",
+            description="Code refactoring mode",
+            type=CommandType.OPTION
+        ),
+        CommandDefinition(
+            name="plan",
+            description="Planning mode",
+            type=CommandType.OPTION
+        ),
+    ]
+    
+    # Main commands
+    COMMANDS = [
+        CommandDefinition(
+            name="help",
+            description="Show available commands",
+            aliases=["h", "?"],
+            examples=["/help", "/?"]
+        ),
+        CommandDefinition(
+            name="exit",
+            description="Exit the application",
+            aliases=["quit", "q"],
+            examples=["/exit", "/quit", "/q"]
+        ),
+        CommandDefinition(
+            name="clear",
+            description="Clear conversation history",
+            aliases=["cls"],
+            examples=["/clear", "/cls"]
+        ),
+        CommandDefinition(
+            name="model",
+            description="Select a different model",
+            aliases=["m"],
+            examples=["/model", "/model gpt-4"]
+        ),
+        CommandDefinition(
+            name="provider",
+            description="Switch provider",
+            aliases=["p"],
+            examples=["/provider", "/provider ollama"]
+        ),
+        CommandDefinition(
+            name="mode",
+            description="Change developer mode",
+            subcommands=MODE_OPTIONS,
+            examples=["/mode", "/mode code", "/mode debug"]
+        ),
+        CommandDefinition(
+            name="session",
+            description="Manage sessions",
+            aliases=["s"],
+            subcommands=SESSION_SUBCOMMANDS,
+            examples=["/session save", "/session list", "/s last"]
+        ),
+        CommandDefinition(
+            name="export",
+            description="Export conversation",
+            aliases=["e"],
+            subcommands=EXPORT_SUBCOMMANDS,
+            examples=["/export json", "/export markdown", "/e html"]
+        ),
+    ]
+    
+    @classmethod
+    def get_command(cls, name: str) -> Optional[CommandDefinition]:
+        """Get command by name or alias."""
+        for cmd in cls.COMMANDS:
+            if name in cmd.get_all_names():
+                return cmd
+        return None
+    
+    @classmethod
+    def get_autocomplete_options(cls) -> Dict[str, List[tuple[str, str]]]:
+        """Get autocomplete options in the format expected by SlashCommandCompleter."""
+        options = {}
+        
+        for cmd in cls.COMMANDS:
+            if cmd.subcommands:
+                options[cmd.name] = [sub.to_autocomplete_tuple() for sub in cmd.subcommands]
+        
+        return options
+    
+    @classmethod
+    def get_command_help(cls, command_name: Optional[str] = None) -> str:
+        """Get formatted help text for a command or all commands."""
+        if command_name:
+            cmd = cls.get_command(command_name)
+            if not cmd:
+                return f"Unknown command: {command_name}"
+            
+            help_text = f"[bold]{cmd.name}[/bold]"
+            if cmd.aliases:
+                help_text += f" (aliases: {', '.join(cmd.aliases)})"
+            help_text += f"\n{cmd.description}\n"
+            
+            if cmd.subcommands:
+                help_text += "\n[bold]Subcommands:[/bold]\n"
+                for sub in cmd.subcommands:
+                    help_text += f"  [cyan]{sub.name}[/cyan]"
+                    if sub.aliases:
+                        help_text += f" ({', '.join(sub.aliases)})"
+                    help_text += f" - {sub.description}\n"
+            
+            if cmd.examples:
+                help_text += "\n[bold]Examples:[/bold]\n"
+                for example in cmd.examples:
+                    help_text += f"  {example}\n"
+            
+            return help_text
+        else:
+            # Return help for all commands
+            help_text = "[bold]Available Commands:[/bold]\n\n"
+            for cmd in cls.COMMANDS:
+                help_text += f"[cyan]/{cmd.name}[/cyan]"
+                if cmd.aliases:
+                    help_text += f" (/{', /'.join(cmd.aliases)})"
+                help_text += f" - {cmd.description}\n"
+            return help_text

--- a/coda/cli/commands_config.yaml
+++ b/coda/cli/commands_config.yaml
@@ -39,12 +39,22 @@ commands:
         description: "Save current conversation"
       - name: load
         description: "Load a saved conversation"
+      - name: last
+        description: "Load the most recent session"
       - name: list
         description: "List all saved sessions"
       - name: branch
         description: "Create a branch from current conversation"
       - name: delete
         description: "Delete a saved session"
+      - name: delete-all
+        description: "Delete all sessions (use --auto-only for just auto-saved)"
+      - name: rename
+        description: "Rename a session"
+      - name: info
+        description: "Show session details"
+      - name: search
+        description: "Search sessions"
 
   theme:
     description: "Change UI theme"

--- a/coda/cli/interactive_cli.py
+++ b/coda/cli/interactive_cli.py
@@ -36,107 +36,12 @@ class SlashCommandCompleter(Completer):
         self.command_options = self._load_command_options()
 
     def _load_command_options(self) -> dict[str, list[tuple[str, str]]]:
-        """Load command options from configuration file."""
-        config_path = Path(__file__).parent / "commands_config.yaml"
+        """Load command options from the command registry."""
+        from coda.cli.command_registry import CommandRegistry
         
-        # First try to use the command registry
-        try:
-            from coda.cli.command_registry import CommandRegistry
-            registry_options = CommandRegistry.get_autocomplete_options()
-            # Add any additional options not in registry
-            registry_options.update({
-                "provider": [
-                    ("oci_genai", "Oracle Cloud Infrastructure GenAI"),
-                    ("ollama", "Local models via Ollama"),
-                    ("openai", "OpenAI GPT models (coming soon)"),
-                    ("litellm", "100+ providers via LiteLLM"),
-                ],
-                "theme": [
-                    ("default", "Default color scheme"),
-                    ("dark", "Dark mode optimized"),
-                    ("light", "Light terminal theme"),
-                    ("minimal", "Minimal colors"),
-                    ("vibrant", "High contrast colors"),
-                ],
-                "tools": [
-                    ("list", "List available MCP tools"),
-                    ("enable", "Enable specific tools"),
-                    ("disable", "Disable specific tools"),
-                    ("config", "Configure tool settings"),
-                    ("status", "Show tool status"),
-                ],
-            })
-            return registry_options
-        except ImportError:
-            pass
-
-        # Fallback to hardcoded options if config file not found
-        default_options = {
-            "mode": [
-                ("general", "General conversation and assistance"),
-                ("code", "Optimized for writing new code"),
-                ("debug", "Focus on error analysis"),
-                ("explain", "Detailed code explanations"),
-                ("review", "Security and code quality review"),
-                ("refactor", "Code improvement suggestions"),
-                ("plan", "Architecture planning and system design"),
-            ],
-            "provider": [
-                ("oci_genai", "Oracle Cloud Infrastructure GenAI"),
-                ("ollama", "Local models via Ollama (coming soon)"),
-                ("openai", "OpenAI GPT models (coming soon)"),
-                ("litellm", "100+ providers via LiteLLM (coming soon)"),
-            ],
-            "session": [
-                ("save", "Save current conversation"),
-                ("load", "Load a saved conversation"),
-                ("last", "Load the most recent session"),
-                ("list", "List all saved sessions"),
-                ("branch", "Create a branch from current conversation"),
-                ("delete", "Delete a saved session"),
-                ("delete-all", "Delete all sessions (use --auto-only for just auto-saved)"),
-                ("rename", "Rename a session"),
-                ("info", "Show session details"),
-                ("search", "Search sessions"),
-            ],
-            "theme": [
-                ("default", "Default color scheme"),
-                ("dark", "Dark mode optimized"),
-                ("light", "Light terminal theme"),
-                ("minimal", "Minimal colors"),
-                ("vibrant", "High contrast colors"),
-            ],
-            "export": [
-                ("markdown", "Export as Markdown file"),
-                ("json", "Export as JSON with metadata"),
-                ("txt", "Export as plain text"),
-                ("html", "Export as HTML with syntax highlighting"),
-            ],
-            "tools": [
-                ("list", "List available MCP tools"),
-                ("enable", "Enable specific tools"),
-                ("disable", "Disable specific tools"),
-                ("config", "Configure tool settings"),
-                ("status", "Show tool status"),
-            ],
-        }
-
-        try:
-            if config_path.exists():
-                with open(config_path) as f:
-                    config = yaml.safe_load(f)
-
-                options = {}
-                for cmd_name, cmd_data in config.get("commands", {}).items():
-                    options[cmd_name] = [
-                        (opt["name"], opt["description"]) for opt in cmd_data.get("options", [])
-                    ]
-                return options
-        except Exception:
-            # If anything fails, use defaults
-            pass
-
-        return default_options
+        # Get autocomplete options from the registry
+        # This currently only includes commands with subcommands
+        return CommandRegistry.get_autocomplete_options()
 
     def get_completions(self, document, complete_event):
         # Get the current text

--- a/coda/cli/interactive_cli.py
+++ b/coda/cli/interactive_cli.py
@@ -59,9 +59,14 @@ class SlashCommandCompleter(Completer):
             "session": [
                 ("save", "Save current conversation"),
                 ("load", "Load a saved conversation"),
+                ("last", "Load the most recent session"),
                 ("list", "List all saved sessions"),
                 ("branch", "Create a branch from current conversation"),
                 ("delete", "Delete a saved session"),
+                ("delete-all", "Delete all sessions (use --auto-only for just auto-saved)"),
+                ("rename", "Rename a session"),
+                ("info", "Show session details"),
+                ("search", "Search sessions"),
             ],
             "theme": [
                 ("default", "Default color scheme"),

--- a/coda/cli/interactive_cli.py
+++ b/coda/cli/interactive_cli.py
@@ -38,6 +38,37 @@ class SlashCommandCompleter(Completer):
     def _load_command_options(self) -> dict[str, list[tuple[str, str]]]:
         """Load command options from configuration file."""
         config_path = Path(__file__).parent / "commands_config.yaml"
+        
+        # First try to use the command registry
+        try:
+            from coda.cli.command_registry import CommandRegistry
+            registry_options = CommandRegistry.get_autocomplete_options()
+            # Add any additional options not in registry
+            registry_options.update({
+                "provider": [
+                    ("oci_genai", "Oracle Cloud Infrastructure GenAI"),
+                    ("ollama", "Local models via Ollama"),
+                    ("openai", "OpenAI GPT models (coming soon)"),
+                    ("litellm", "100+ providers via LiteLLM"),
+                ],
+                "theme": [
+                    ("default", "Default color scheme"),
+                    ("dark", "Dark mode optimized"),
+                    ("light", "Light terminal theme"),
+                    ("minimal", "Minimal colors"),
+                    ("vibrant", "High contrast colors"),
+                ],
+                "tools": [
+                    ("list", "List available MCP tools"),
+                    ("enable", "Enable specific tools"),
+                    ("disable", "Disable specific tools"),
+                    ("config", "Configure tool settings"),
+                    ("status", "Show tool status"),
+                ],
+            })
+            return registry_options
+        except ImportError:
+            pass
 
         # Fallback to hardcoded options if config file not found
         default_options = {

--- a/coda/cli/interactive_cli.py
+++ b/coda/cli/interactive_cli.py
@@ -15,6 +15,7 @@ from prompt_toolkit.styles import Style
 from rich.console import Console
 
 from .shared import CommandHandler, CommandResult, DeveloperMode
+from coda.session import SessionCommands
 
 
 class SlashCommand:
@@ -212,6 +213,9 @@ class InteractiveCLI(CommandHandler):
         self.escape_count = 0
         self.last_ctrl_c_time = 0
         self.ctrl_c_count = 0
+        
+        # Initialize session management
+        self.session_commands = SessionCommands()
 
         # Initialize session with all features
         self._init_session()
@@ -430,13 +434,10 @@ class InteractiveCLI(CommandHandler):
 
     def _cmd_session(self, args: str):
         """Manage sessions."""
-        if not args:
-            options = self.session.completer.slash_completer.command_options.get("session", [])
-            self._show_coming_soon_command(
-                "session", "Session Management", options, "/session <subcommand>"
-            )
-        else:
-            self.console.print(f"[yellow]Session command '{args}' not implemented yet[/yellow]")
+        # Pass the arguments to session commands handler
+        result = self.session_commands.handle_session_command(args.split() if args else [])
+        if result:
+            self.console.print(result)
 
     def _cmd_theme(self, args: str):
         """Change UI theme."""
@@ -450,13 +451,10 @@ class InteractiveCLI(CommandHandler):
 
     def _cmd_export(self, args: str):
         """Export conversation."""
-        if not args:
-            options = self.session.completer.slash_completer.command_options.get("export", [])
-            self._show_coming_soon_command(
-                "export", "Export Options", options, "/export <format> [filename]"
-            )
-        else:
-            self.console.print(f"[yellow]Export format '{args}' not implemented yet[/yellow]")
+        # Pass the arguments to session commands handler for export
+        result = self.session_commands.handle_export_command(args.split() if args else [])
+        if result:
+            self.console.print(result)
 
     def _cmd_tools(self, args: str):
         """Manage MCP tools."""
@@ -470,7 +468,9 @@ class InteractiveCLI(CommandHandler):
 
     def _cmd_clear(self, args: str):
         """Clear conversation."""
-        self.console.print("[yellow]Conversation cleared (placeholder)[/yellow]")
+        # Clear session manager's conversation
+        self.session_commands.clear_conversation()
+        self.console.print("[green]Conversation cleared[/green]")
         # Note: Actual clearing is handled by the caller
 
     def _cmd_exit(self, args: str):

--- a/coda/cli/interactive_cli.py
+++ b/coda/cli/interactive_cli.py
@@ -257,19 +257,39 @@ class InteractiveCLI(CommandHandler):
         self._init_session()
 
     def _init_commands(self) -> dict[str, SlashCommand]:
-        """Initialize slash commands."""
-        return {
-            "help": SlashCommand("help", self._cmd_help, "Show available commands", ["h", "?"]),
-            "model": SlashCommand("model", self._cmd_model, "Switch AI model", ["m"]),
-            "provider": SlashCommand("provider", self._cmd_provider, "Switch provider", ["p"]),
-            "mode": SlashCommand("mode", self._cmd_mode, "Change developer mode"),
-            "session": SlashCommand("session", self._cmd_session, "Manage sessions", ["s"]),
-            "theme": SlashCommand("theme", self._cmd_theme, "Change UI theme"),
-            "export": SlashCommand("export", self._cmd_export, "Export conversation", ["e"]),
-            "tools": SlashCommand("tools", self._cmd_tools, "Manage MCP tools", ["t"]),
-            "clear": SlashCommand("clear", self._cmd_clear, "Clear conversation", ["cls"]),
-            "exit": SlashCommand("exit", self._cmd_exit, "Exit the application", ["quit", "q"]),
+        """Initialize slash commands from the command registry."""
+        from coda.cli.command_registry import CommandRegistry
+        
+        # Map command names to their handlers
+        handler_map = {
+            "help": self._cmd_help,
+            "model": self._cmd_model,
+            "provider": self._cmd_provider,
+            "mode": self._cmd_mode,
+            "session": self._cmd_session,
+            "export": self._cmd_export,
+            "clear": self._cmd_clear,
+            "exit": self._cmd_exit,
         }
+        
+        # Add handlers for commands not yet implemented
+        placeholder_handlers = {
+            "theme": self._cmd_theme,
+            "tools": self._cmd_tools,
+        }
+        handler_map.update(placeholder_handlers)
+        
+        commands = {}
+        for cmd_def in CommandRegistry.COMMANDS:
+            if cmd_def.name in handler_map:
+                commands[cmd_def.name] = SlashCommand(
+                    name=cmd_def.name,
+                    handler=handler_map[cmd_def.name],
+                    help_text=cmd_def.description,
+                    aliases=cmd_def.aliases
+                )
+        
+        return commands
 
     def _create_style(self) -> Style:
         """Create custom style for the prompt."""

--- a/coda/cli/main.py
+++ b/coda/cli/main.py
@@ -32,8 +32,9 @@ console = Console()
     default="general",
     help="Initial developer mode (basic mode only)",
 )
+@click.option("--no-save", is_flag=True, help="Disable auto-saving of conversations")
 @click.version_option(version=__version__, prog_name="coda")
-def main(provider: str, model: str, debug: bool, one_shot: str, basic: bool, mode: str):
+def main(provider: str, model: str, debug: bool, one_shot: str, basic: bool, mode: str, no_save: bool):
     """Coda - A multi-provider code assistant"""
 
     # Load configuration
@@ -61,6 +62,7 @@ def main(provider: str, model: str, debug: bool, one_shot: str, basic: bool, mod
                 debug=debug,
                 one_shot=one_shot,
                 mode=mode,
+                no_save=no_save,
             )
             return
         except ImportError:

--- a/coda/cli/main.py
+++ b/coda/cli/main.py
@@ -33,8 +33,9 @@ console = Console()
     help="Initial developer mode (basic mode only)",
 )
 @click.option("--no-save", is_flag=True, help="Disable auto-saving of conversations")
+@click.option("--resume", is_flag=True, help="Resume the most recent session")
 @click.version_option(version=__version__, prog_name="coda")
-def main(provider: str, model: str, debug: bool, one_shot: str, basic: bool, mode: str, no_save: bool):
+def main(provider: str, model: str, debug: bool, one_shot: str, basic: bool, mode: str, no_save: bool, resume: bool):
     """Coda - A multi-provider code assistant"""
 
     # Load configuration
@@ -63,6 +64,7 @@ def main(provider: str, model: str, debug: bool, one_shot: str, basic: bool, mod
                 one_shot=one_shot,
                 mode=mode,
                 no_save=no_save,
+                resume=resume,
             )
             return
         except ImportError:

--- a/coda/cli/shared/help.py
+++ b/coda/cli/shared/help.py
@@ -10,7 +10,7 @@ def print_command_help(console: Console, mode: str = ""):
     # Try to use command registry
     try:
         from coda.cli.command_registry import CommandRegistry
-        help_text = CommandRegistry.get_command_help()
+        help_text = CommandRegistry.get_command_help(mode=mode)
         console.print(help_text)
         return
     except ImportError:

--- a/coda/cli/shared/help.py
+++ b/coda/cli/shared/help.py
@@ -7,6 +7,16 @@ from .modes import DeveloperMode, get_mode_description
 
 def print_command_help(console: Console, mode: str = ""):
     """Print the command help section."""
+    # Try to use command registry
+    try:
+        from coda.cli.command_registry import CommandRegistry
+        help_text = CommandRegistry.get_command_help()
+        console.print(help_text)
+        return
+    except ImportError:
+        pass
+    
+    # Fallback to hardcoded help
     mode_suffix = f" ({mode})" if mode else ""
     console.print(f"\n[bold]Available Commands{mode_suffix}[/bold]\n")
 
@@ -14,6 +24,11 @@ def print_command_help(console: Console, mode: str = ""):
     console.print("  [cyan]/model[/cyan] (/m) - Switch AI model")
     console.print("  [cyan]/provider[/cyan] (/p) - Switch provider")
     console.print("  [cyan]/mode[/cyan] - Change developer mode")
+    console.print()
+
+    console.print("[bold]Session Management:[/bold]")
+    console.print("  [cyan]/session[/cyan] (/s) - Save/load/manage conversations")
+    console.print("  [cyan]/export[/cyan] (/e) - Export conversation to file")
     console.print()
 
     console.print("[bold]System:[/bold]")
@@ -63,10 +78,8 @@ def print_interactive_keyboard_shortcuts(console: Console):
 def print_interactive_only_commands(console: Console):
     """Print commands that are only available in interactive mode."""
     console.print("[bold]Session:[/bold] [dim](Interactive mode only)[/dim]")
-    console.print("  [cyan]/session[/cyan] (/s) - Manage sessions [yellow](Coming soon)[/yellow]")
-    console.print(
-        "  [cyan]/export[/cyan] (/e) - Export conversation [yellow](Coming soon)[/yellow]"
-    )
+    console.print("  [cyan]/session[/cyan] (/s) - Save/load/manage conversations")
+    console.print("  [cyan]/export[/cyan] (/e) - Export conversation to file")
     console.print()
 
     console.print("[bold]Advanced:[/bold] [dim](Interactive mode only)[/dim]")

--- a/coda/providers/__init__.py
+++ b/coda/providers/__init__.py
@@ -11,6 +11,7 @@ from coda.providers.base import (
 from coda.providers.litellm_provider import LiteLLMProvider
 from coda.providers.oci_genai import OCIGenAIProvider
 from coda.providers.ollama_provider import OllamaProvider
+from coda.providers.mock_provider import MockProvider
 from coda.providers.registry import ProviderFactory, ProviderRegistry
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "OCIGenAIProvider",
     "LiteLLMProvider",
     "OllamaProvider",
+    "MockProvider",
     "ProviderRegistry",
     "ProviderFactory",
 ]

--- a/coda/providers/litellm_provider.py
+++ b/coda/providers/litellm_provider.py
@@ -55,14 +55,8 @@ class LiteLLMProvider(BaseProvider):
 
     def _convert_messages(self, messages: list[Message]) -> list[dict]:
         """Convert our Message objects to LiteLLM format."""
-        return [
-            {
-                "role": msg.role.value,
-                "content": msg.content,
-                **({"name": msg.name} if msg.name else {}),
-            }
-            for msg in messages
-        ]
+        from .utils import convert_messages_with_name
+        return convert_messages_with_name(messages)
 
     def chat(
         self,

--- a/coda/providers/mock_provider.py
+++ b/coda/providers/mock_provider.py
@@ -1,0 +1,187 @@
+"""Mock provider for testing session functionality."""
+
+from typing import List, Dict, Any, Iterator
+import time
+from datetime import datetime
+
+from .base import BaseProvider, Model, Message, Role
+
+
+class MockProvider(BaseProvider):
+    """Mock provider that echoes back user input with context awareness."""
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.conversation_history = []
+    
+    @property
+    def name(self) -> str:
+        """Provider name."""
+        return "mock"
+    
+    def list_models(self) -> List[Model]:
+        """Return mock models for testing."""
+        return [
+            Model(
+                id="mock-echo",
+                name="Mock Echo Model",
+                provider="mock",
+                metadata={
+                    "capabilities": ["CHAT"],
+                    "context_window": 4096,
+                    "description": "Echoes back with conversation awareness"
+                }
+            ),
+            Model(
+                id="mock-smart",
+                name="Mock Smart Model", 
+                provider="mock",
+                metadata={
+                    "capabilities": ["CHAT"],
+                    "context_window": 8192,
+                    "description": "Provides contextual responses"
+                }
+            )
+        ]
+    
+    def chat(
+        self,
+        messages: List[Message],
+        model: str,
+        **kwargs
+    ) -> str:
+        """Generate a mock response based on the conversation."""
+        # Store conversation for context
+        self.conversation_history = messages
+        
+        # Get the last user message
+        user_messages = [msg for msg in messages if msg.role == Role.USER]
+        if not user_messages:
+            return "I don't see any user messages to respond to."
+        
+        last_message = user_messages[-1].content.lower()
+        
+        # Generate contextual responses based on conversation
+        # IMPORTANT: Check for memory questions FIRST before topic-specific responses
+        if "what were we discussing" in last_message or "talking about" in last_message:
+            # Only look for topics in PREVIOUS messages (not the current one asking about discussion)
+            topics = []
+            previous_messages = messages[:-1]  # Exclude the current "what were we discussing" message
+            
+            if not previous_messages:
+                return "I don't see any previous conversation to reference."
+            
+            for msg in previous_messages:
+                content = msg.content.lower()
+                if "python" in content:
+                    topics.append("Python programming")
+                if "decorator" in content:
+                    topics.append("Python decorators")
+                if "javascript" in content:
+                    topics.append("JavaScript")
+            
+            if topics:
+                return f"We were discussing: {', '.join(set(topics))}. What would you like to know more about?"
+            else:
+                return "I don't see any specific topics we were discussing previously."
+        
+        elif "python" in last_message:
+            if any("decorator" in msg.content.lower() for msg in messages):
+                return "Yes, we were discussing Python decorators. They are functions that modify other functions, using the @decorator syntax."
+            else:
+                return "Python is a high-level programming language known for its simplicity and readability."
+        
+        elif "javascript" in last_message:
+            return "JavaScript is a dynamic programming language primarily used for web development."
+        
+        elif "decorator" in last_message and len(messages) == 1:
+            # If this is the only message, provide general info
+            return "Decorators in Python are a way to modify functions using the @ syntax. For example: @property or @staticmethod."
+        
+        elif "decorator" in last_message and len(messages) > 1:
+            # If part of a conversation, check for context
+            if any("decorator" in msg.content.lower() for msg in messages[:-1]):
+                return "Yes, we were discussing Python decorators. They are functions that modify other functions, using the @decorator syntax."
+            else:
+                return "Decorators in Python are a way to modify functions using the @ syntax. For example: @property or @staticmethod."
+        
+        elif "hello" in last_message or "hi" in last_message:
+            return "Hello! How can I help you today?"
+        
+        elif "help" in last_message:
+            return "I'm a mock AI assistant. I can help you test session management features."
+        
+        else:
+            # Echo back with conversation context
+            response_parts = [f"You said: '{user_messages[-1].content}'"]
+            
+            if len(messages) > 1:
+                response_parts.append(f"This is message #{len([m for m in messages if m.role == Role.USER])} in our conversation.")
+            
+            # Add context about previous messages
+            if len(user_messages) > 1:
+                response_parts.append(f"Earlier you asked about: '{user_messages[-2].content[:50]}...'")
+            
+            return " ".join(response_parts)
+    
+    def chat_stream(
+        self,
+        messages: List[Message],
+        model: str,
+        **kwargs
+    ) -> Iterator[Message]:
+        """Stream a mock response word by word."""
+        response = self.chat(messages, model, **kwargs)
+        
+        # Simulate streaming by yielding words
+        words = response.split()
+        for i, word in enumerate(words):
+            # Add space except for first word
+            content = word if i == 0 else f" {word}"
+            
+            yield Message(
+                role=Role.ASSISTANT,
+                content=content
+            )
+            
+            # Small delay to simulate real streaming
+            time.sleep(0.01)
+    
+    def get_model_info(self, model_id: str) -> Dict[str, Any]:
+        """Get information about a specific model."""
+        models = {m.id: m for m in self.list_models()}
+        if model_id in models:
+            model = models[model_id]
+            return {
+                "id": model.id,
+                "name": model.name,
+                "provider": model.provider,
+                "capabilities": model.metadata.get("capabilities", []),
+                "context_window": model.metadata.get("context_window", 4096),
+                "description": model.metadata.get("description", "")
+            }
+        
+        raise ValueError(f"Model {model_id} not found")
+    
+    async def achat(
+        self,
+        messages: List[Message],
+        model: str,
+        **kwargs
+    ) -> str:
+        """Async version of chat (delegates to sync)."""
+        return self.chat(messages, model, **kwargs)
+    
+    async def achat_stream(
+        self,
+        messages: List[Message],
+        model: str,
+        **kwargs
+    ) -> Iterator[Message]:
+        """Async version of chat_stream (delegates to sync)."""
+        for chunk in self.chat_stream(messages, model, **kwargs):
+            yield chunk
+    
+    def is_available(self) -> bool:
+        """Mock provider is always available."""
+        return True

--- a/coda/providers/ollama_provider.py
+++ b/coda/providers/ollama_provider.py
@@ -39,13 +39,8 @@ class OllamaProvider(BaseProvider):
 
     def _convert_messages(self, messages: list[Message]) -> list[dict]:
         """Convert our Message objects to Ollama format."""
-        return [
-            {
-                "role": msg.role.value,
-                "content": msg.content,
-            }
-            for msg in messages
-        ]
+        from .utils import convert_messages_basic
+        return convert_messages_basic(messages)
 
     def _extract_model_info(self, model_data: dict) -> Model:
         """Extract model information from Ollama model data."""

--- a/coda/providers/registry.py
+++ b/coda/providers/registry.py
@@ -6,6 +6,7 @@ from coda.providers.base import BaseProvider
 from coda.providers.litellm_provider import LiteLLMProvider
 from coda.providers.oci_genai import OCIGenAIProvider
 from coda.providers.ollama_provider import OllamaProvider
+from coda.providers.mock_provider import MockProvider
 
 
 class ProviderRegistry:
@@ -116,6 +117,7 @@ class ProviderRegistry:
 ProviderRegistry.register("oci_genai", OCIGenAIProvider)
 ProviderRegistry.register("litellm", LiteLLMProvider)
 ProviderRegistry.register("ollama", OllamaProvider)
+ProviderRegistry.register("mock", MockProvider)
 
 
 class ProviderFactory:

--- a/coda/providers/utils.py
+++ b/coda/providers/utils.py
@@ -1,0 +1,103 @@
+"""Shared utilities for provider implementations."""
+
+from typing import List, Dict, Any, Optional
+
+from .base import Message
+
+
+def convert_messages_basic(messages: List[Message]) -> List[Dict[str, Any]]:
+    """Convert Message objects to basic format for most providers.
+    
+    Args:
+        messages: List of Message objects
+        
+    Returns:
+        List of message dictionaries with role and content
+    """
+    return [
+        {
+            "role": msg.role.value,
+            "content": msg.content,
+        }
+        for msg in messages
+    ]
+
+
+def convert_messages_with_name(messages: List[Message]) -> List[Dict[str, Any]]:
+    """Convert Message objects to format supporting name field (e.g., OpenAI/LiteLLM).
+    
+    Args:
+        messages: List of Message objects
+        
+    Returns:
+        List of message dictionaries with role, content, and optional name
+    """
+    return [
+        {
+            "role": msg.role.value,
+            "content": msg.content,
+            **({"name": msg.name} if msg.name else {}),
+        }
+        for msg in messages
+    ]
+
+
+def extract_basic_model_info(model_data: Dict[str, Any], name_key: str = "name") -> Dict[str, Any]:
+    """Extract basic model information from provider model data.
+    
+    Args:
+        model_data: Raw model data from provider
+        name_key: Key to use for model name
+        
+    Returns:
+        Standardized model info dictionary
+    """
+    return {
+        "name": model_data.get(name_key, "unknown"),
+        "provider": model_data.get("provider", "unknown"),
+        "description": model_data.get("description", ""),
+        "context_length": model_data.get("context_length", 4096),
+        "capabilities": model_data.get("capabilities", []),
+    }
+
+
+def build_request_params(
+    model: str,
+    temperature: float = 0.7,
+    max_tokens: Optional[int] = None,
+    top_p: Optional[float] = None,
+    stop: Optional[List[str]] = None,
+    stream: bool = False,
+    **kwargs
+) -> Dict[str, Any]:
+    """Build common request parameters for provider API calls.
+    
+    Args:
+        model: Model name
+        temperature: Sampling temperature
+        max_tokens: Maximum tokens to generate
+        top_p: Top-p sampling parameter
+        stop: Stop sequences
+        stream: Whether to stream responses
+        **kwargs: Additional parameters
+        
+    Returns:
+        Parameters dictionary
+    """
+    params = {
+        "model": model,
+        "temperature": temperature,
+        "stream": stream,
+    }
+    
+    if max_tokens is not None:
+        params["max_tokens"] = max_tokens
+    if top_p is not None:
+        params["top_p"] = top_p
+    if stop:
+        params["stop"] = stop if isinstance(stop, list) else [stop]
+    
+    # Add any additional parameters
+    params.update(kwargs)
+    
+    return params

--- a/coda/session/__init__.py
+++ b/coda/session/__init__.py
@@ -1,0 +1,17 @@
+"""Session management module for Coda."""
+
+from .database import SessionDatabase
+from .manager import SessionManager
+from .models import Session, Message
+from .commands import SessionCommands
+from .context import ContextManager, ContextWindow
+
+__all__ = [
+    "SessionDatabase", 
+    "SessionManager", 
+    "Session", 
+    "Message",
+    "SessionCommands",
+    "ContextManager",
+    "ContextWindow"
+]

--- a/coda/session/commands.py
+++ b/coda/session/commands.py
@@ -69,7 +69,14 @@ class SessionCommands:
     
     def _show_session_help(self) -> str:
         """Show session command help."""
-        help_text = """
+        from coda.cli.command_registry import CommandRegistry
+        
+        session_cmd = CommandRegistry.get_command("session")
+        if session_cmd:
+            help_text = CommandRegistry.get_command_help("session")
+        else:
+            # Fallback if registry not available
+            help_text = """
 [bold]Session Management Commands[/bold]
 
 [cyan]/session save [name][/cyan] - Save current conversation
@@ -85,6 +92,7 @@ class SessionCommands:
 
 [dim]Aliases: /s, save→s, load→l, list→ls, branch→b, delete→d/rm, info→i, rename→r[/dim]
 """
+        
         self.console.print(Panel(help_text, title="Session Help", border_style="blue"))
         return None
     

--- a/coda/session/commands.py
+++ b/coda/session/commands.py
@@ -1,0 +1,552 @@
+"""Session management commands for the interactive CLI."""
+
+from typing import Optional, List, Dict, Any, Tuple
+from datetime import datetime
+import os
+
+from rich.console import Console
+from rich.table import Table
+from rich.prompt import Prompt, Confirm
+from rich.panel import Panel
+from rich.syntax import Syntax
+
+from .manager import SessionManager
+from .models import Session, Message
+
+
+class SessionCommands:
+    """Handles session-related slash commands."""
+    
+    def __init__(self, session_manager: Optional[SessionManager] = None):
+        """Initialize session commands.
+        
+        Args:
+            session_manager: SessionManager instance. If None, creates a new one.
+        """
+        self.manager = session_manager or SessionManager()
+        self.console = Console()
+        self.current_session_id: Optional[str] = None
+        self.current_messages: List[Dict[str, Any]] = []
+    
+    def handle_session_command(self, args: List[str]) -> Optional[str]:
+        """Handle /session command and subcommands.
+        
+        Args:
+            args: Command arguments
+            
+        Returns:
+            Response message or None
+        """
+        if not args:
+            return self._show_session_help()
+        
+        subcommand = args[0].lower()
+        
+        if subcommand in ['save', 's']:
+            return self._save_session(args[1:])
+        elif subcommand in ['load', 'l']:
+            return self._load_session(args[1:])
+        elif subcommand in ['list', 'ls']:
+            return self._list_sessions(args[1:])
+        elif subcommand in ['branch', 'b']:
+            return self._branch_session(args[1:])
+        elif subcommand in ['delete', 'd', 'rm']:
+            return self._delete_session(args[1:])
+        elif subcommand in ['info', 'i']:
+            return self._session_info(args[1:])
+        elif subcommand in ['search']:
+            return self._search_sessions(args[1:])
+        else:
+            return f"Unknown session subcommand: {subcommand}. Use /session help for options."
+    
+    def _show_session_help(self) -> str:
+        """Show session command help."""
+        help_text = """
+[bold]Session Management Commands[/bold]
+
+[cyan]/session save [name][/cyan] - Save current conversation
+[cyan]/session load <id|name>[/cyan] - Load a saved session
+[cyan]/session list[/cyan] - List all saved sessions
+[cyan]/session branch [name][/cyan] - Create a branch from current session
+[cyan]/session delete <id|name>[/cyan] - Delete a session
+[cyan]/session info [id][/cyan] - Show session details
+[cyan]/session search <query>[/cyan] - Search sessions
+
+[dim]Aliases: /s, save→s, load→l, list→ls, branch→b, delete→d/rm, info→i[/dim]
+"""
+        self.console.print(Panel(help_text, title="Session Help", border_style="blue"))
+        return None
+    
+    def _save_session(self, args: List[str]) -> str:
+        """Save current conversation as a session."""
+        if not self.current_messages:
+            return "No messages to save."
+        
+        # Get session name
+        if args:
+            name = " ".join(args)
+        else:
+            name = Prompt.ask("Session name", default=f"Session {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+        
+        # Get description
+        description = Prompt.ask("Description (optional)", default="")
+        
+        # Create or update session
+        if self.current_session_id:
+            # Update existing session
+            self.manager.update_session(
+                self.current_session_id,
+                name=name,
+                description=description if description else None
+            )
+            return f"Session updated: {name}"
+        else:
+            # Create new session
+            # Get provider and model from first assistant message
+            provider = "unknown"
+            model = "unknown"
+            mode = "general"
+            
+            for msg in self.current_messages:
+                if msg.get('role') == 'assistant' and msg.get('metadata'):
+                    provider = msg['metadata'].get('provider', provider)
+                    model = msg['metadata'].get('model', model)
+                    mode = msg['metadata'].get('mode', mode)
+                    break
+            
+            session = self.manager.create_session(
+                name=name,
+                description=description if description else None,
+                provider=provider,
+                model=model,
+                mode=mode
+            )
+            
+            # Save all messages
+            for msg in self.current_messages:
+                self.manager.add_message(
+                    session_id=session.id,
+                    role=msg['role'],
+                    content=msg['content'],
+                    metadata=msg.get('metadata', {}),
+                    model=msg.get('metadata', {}).get('model'),
+                    provider=msg.get('metadata', {}).get('provider'),
+                    token_usage=msg.get('metadata', {}).get('token_usage'),
+                    cost=msg.get('metadata', {}).get('cost')
+                )
+            
+            self.current_session_id = session.id
+            return f"Session saved: {name} (ID: {session.id[:8]}...)"
+    
+    def _load_session(self, args: List[str]) -> str:
+        """Load a saved session."""
+        if not args:
+            return "Please specify a session ID or name to load."
+        
+        session_ref = " ".join(args)
+        
+        # Try to find session by ID or name
+        session = self._find_session(session_ref)
+        if not session:
+            return f"Session not found: {session_ref}"
+        
+        # Load messages
+        messages = self.manager.get_messages(session.id)
+        
+        # Convert to internal format
+        self.current_messages = []
+        for msg in messages:
+            self.current_messages.append({
+                'role': msg.role,
+                'content': msg.content,
+                'metadata': {
+                    'provider': msg.provider or session.provider,
+                    'model': msg.model or session.model,
+                    'mode': msg.message_metadata.get('mode', session.mode),
+                    'token_usage': {
+                        'prompt_tokens': msg.prompt_tokens,
+                        'completion_tokens': msg.completion_tokens,
+                        'total_tokens': msg.total_tokens
+                    } if msg.total_tokens else None,
+                    'cost': msg.cost
+                }
+            })
+        
+        self.current_session_id = session.id
+        
+        # Display session info
+        self.console.print(f"\n[green]Loaded session:[/green] {session.name}")
+        self.console.print(f"[dim]Provider:[/dim] {session.provider} | [dim]Model:[/dim] {session.model}")
+        self.console.print(f"[dim]Messages:[/dim] {len(messages)} | [dim]Created:[/dim] {session.created_at.strftime('%Y-%m-%d %H:%M')}")
+        
+        if session.description:
+            self.console.print(f"[dim]Description:[/dim] {session.description}")
+        
+        # Set flag to indicate messages were loaded for CLI integration
+        self._messages_loaded = True
+        
+        return None
+    
+    def _list_sessions(self, args: List[str]) -> str:
+        """List saved sessions."""
+        sessions = self.manager.get_active_sessions(limit=50)
+        
+        if not sessions:
+            return "No saved sessions found."
+        
+        # Create table
+        table = Table(title="Saved Sessions", show_header=True, header_style="bold cyan")
+        table.add_column("ID", style="dim", width=12)
+        table.add_column("Name", style="bold")
+        table.add_column("Provider/Model", style="cyan")
+        table.add_column("Messages", justify="right")
+        table.add_column("Last Active", style="green")
+        
+        for session in sessions:
+            table.add_row(
+                session.id[:8] + "...",
+                session.name[:40] + ("..." if len(session.name) > 40 else ""),
+                f"{session.provider}/{session.model.split('.')[-1][:20]}",
+                str(session.message_count),
+                session.accessed_at.strftime('%Y-%m-%d %H:%M')
+            )
+        
+        self.console.print(table)
+        return None
+    
+    def _branch_session(self, args: List[str]) -> str:
+        """Create a branch from current session."""
+        if not self.current_session_id:
+            return "No active session to branch from. Save or load a session first."
+        
+        # Get branch name
+        if args:
+            name = " ".join(args)
+        else:
+            parent_session = self.manager.get_session(self.current_session_id)
+            name = Prompt.ask("Branch name", default=f"{parent_session.name} (branch)")
+        
+        # Get last message ID for branch point
+        messages = self.manager.get_messages(self.current_session_id)
+        if not messages:
+            return "No messages in current session to branch from."
+        
+        last_message = messages[-1]
+        
+        # Create branch
+        branch_session = self.manager.create_session(
+            name=name,
+            provider=messages[0].provider or "unknown",
+            model=messages[0].model or "unknown",
+            mode=self.current_messages[0].get('metadata', {}).get('mode', 'general'),
+            parent_id=self.current_session_id,
+            branch_point_message_id=last_message.id
+        )
+        
+        # Switch to branch
+        self.current_session_id = branch_session.id
+        
+        return f"Created branch: {name} (ID: {branch_session.id[:8]}...)"
+    
+    def _delete_session(self, args: List[str]) -> str:
+        """Delete a session."""
+        if not args:
+            return "Please specify a session ID or name to delete."
+        
+        session_ref = " ".join(args)
+        
+        # Find session
+        session = self._find_session(session_ref)
+        if not session:
+            return f"Session not found: {session_ref}"
+        
+        # Confirm deletion
+        if not Confirm.ask(f"Delete session '{session.name}'?"):
+            return "Deletion cancelled."
+        
+        # Check if it's the current session
+        if session.id == self.current_session_id:
+            self.current_session_id = None
+        
+        # Delete session
+        self.manager.delete_session(session.id)
+        
+        return f"Session deleted: {session.name}"
+    
+    def _session_info(self, args: List[str]) -> str:
+        """Show detailed session information."""
+        if args:
+            session_ref = " ".join(args)
+            session = self._find_session(session_ref)
+            if not session:
+                return f"Session not found: {session_ref}"
+        elif self.current_session_id:
+            session = self.manager.get_session(self.current_session_id)
+        else:
+            return "No session specified or loaded."
+        
+        # Create info panel
+        info_lines = [
+            f"[bold]Name:[/bold] {session.name}",
+            f"[bold]ID:[/bold] {session.id}",
+            f"[bold]Provider:[/bold] {session.provider}",
+            f"[bold]Model:[/bold] {session.model}",
+            f"[bold]Mode:[/bold] {session.mode}",
+            f"[bold]Status:[/bold] {session.status}",
+            f"[bold]Created:[/bold] {session.created_at.strftime('%Y-%m-%d %H:%M:%S')}",
+            f"[bold]Updated:[/bold] {session.updated_at.strftime('%Y-%m-%d %H:%M:%S')}",
+            f"[bold]Messages:[/bold] {session.message_count}",
+            f"[bold]Total Tokens:[/bold] {session.total_tokens:,}" if session.total_tokens else "[bold]Total Tokens:[/bold] 0",
+        ]
+        
+        if session.total_cost:
+            info_lines.append(f"[bold]Total Cost:[/bold] ${session.total_cost:.4f}")
+        
+        if session.description:
+            info_lines.append(f"\n[bold]Description:[/bold]\n{session.description}")
+        
+        if session.parent_id:
+            parent = self.manager.get_session(session.parent_id)
+            if parent:
+                info_lines.append(f"\n[bold]Branched from:[/bold] {parent.name}")
+        
+        self.console.print(Panel("\n".join(info_lines), title="Session Information", border_style="blue"))
+        return None
+    
+    def _search_sessions(self, args: List[str]) -> str:
+        """Search sessions by content."""
+        if not args:
+            return "Please provide a search query."
+        
+        query = " ".join(args)
+        results = self.manager.search_sessions(query, limit=10)
+        
+        if not results:
+            return f"No sessions found matching: {query}"
+        
+        self.console.print(f"\n[bold]Search Results for:[/bold] {query}\n")
+        
+        for session, messages in results:
+            self.console.print(f"[bold cyan]{session.name}[/bold cyan] ({session.id[:8]}...)")
+            self.console.print(f"[dim]{session.provider}/{session.model} - {session.message_count} messages[/dim]")
+            
+            # Show matching messages
+            for msg in messages[:3]:  # Show up to 3 matches
+                excerpt = msg.content[:100].replace('\n', ' ')
+                if len(msg.content) > 100:
+                    excerpt += "..."
+                self.console.print(f"  [yellow]→[/yellow] [{msg.role}] {excerpt}")
+            
+            if len(messages) > 3:
+                self.console.print(f"  [dim]... and {len(messages) - 3} more matches[/dim]")
+            
+            self.console.print()
+        
+        return None
+    
+    def _find_session(self, session_ref: str) -> Optional[Session]:
+        """Find session by ID or name."""
+        # First try by ID
+        sessions = self.manager.get_active_sessions(limit=100)
+        
+        # Try exact ID match
+        for session in sessions:
+            if session.id == session_ref or session.id.startswith(session_ref):
+                return session
+        
+        # Try name match (case insensitive)
+        session_ref_lower = session_ref.lower()
+        for session in sessions:
+            if session.name.lower() == session_ref_lower:
+                return session
+        
+        # Try partial name match
+        for session in sessions:
+            if session_ref_lower in session.name.lower():
+                return session
+        
+        return None
+    
+    def handle_export_command(self, args: List[str]) -> Optional[str]:
+        """Handle /export command.
+        
+        Args:
+            args: Command arguments
+            
+        Returns:
+            Response message or None
+        """
+        if not args:
+            return self._show_export_help()
+        
+        format = args[0].lower()
+        if format not in ['json', 'markdown', 'md', 'txt', 'text', 'html']:
+            return f"Unknown export format: {format}. Use: json, markdown, txt, or html"
+        
+        # Normalize format names
+        if format == 'md':
+            format = 'markdown'
+        elif format == 'text':
+            format = 'txt'
+        
+        # Get session to export
+        if len(args) > 1:
+            session_ref = " ".join(args[1:])
+            session = self._find_session(session_ref)
+            if not session:
+                return f"Session not found: {session_ref}"
+            session_id = session.id
+        elif self.current_session_id:
+            session_id = self.current_session_id
+            session = self.manager.get_session(session_id)
+        else:
+            return "No session specified or loaded."
+        
+        # Export session
+        try:
+            content = self.manager.export_session(session_id, format)
+            
+            # Generate filename
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+            safe_name = "".join(c for c in session.name if c.isalnum() or c in (' ', '-', '_')).rstrip()
+            filename = f"{safe_name}_{timestamp}.{format}"
+            
+            # Get export directory
+            export_dir = os.path.expanduser("~/Documents/coda_exports")
+            os.makedirs(export_dir, exist_ok=True)
+            filepath = os.path.join(export_dir, filename)
+            
+            # Write file
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(content)
+            
+            self.console.print(f"[green]✓[/green] Exported to: {filepath}")
+            return None
+            
+        except Exception as e:
+            return f"Export failed: {str(e)}"
+    
+    def _show_export_help(self) -> str:
+        """Show export command help."""
+        help_text = """
+[bold]Export Commands[/bold]
+
+[cyan]/export json [session][/cyan] - Export as JSON
+[cyan]/export markdown [session][/cyan] - Export as Markdown
+[cyan]/export txt [session][/cyan] - Export as plain text
+[cyan]/export html [session][/cyan] - Export as HTML
+
+[dim]Aliases: /e, markdown→md, txt→text[/dim]
+[dim]If no session specified, exports current session[/dim]
+[dim]Files saved to: ~/Documents/coda_exports/[/dim]
+"""
+        self.console.print(Panel(help_text, title="Export Help", border_style="blue"))
+        return None
+    
+    def add_message(
+        self,
+        role: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None
+    ):
+        """Add a message to the current conversation.
+        
+        Args:
+            role: Message role
+            content: Message content
+            metadata: Optional metadata
+        """
+        msg = {
+            'role': role,
+            'content': content,
+            'metadata': metadata or {}
+        }
+        self.current_messages.append(msg)
+        
+        # If we have an active session, save to database
+        if self.current_session_id:
+            self.manager.add_message(
+                session_id=self.current_session_id,
+                role=role,
+                content=content,
+                metadata=metadata,
+                model=metadata.get('model') if metadata else None,
+                provider=metadata.get('provider') if metadata else None,
+                token_usage=metadata.get('token_usage') if metadata else None,
+                cost=metadata.get('cost') if metadata else None
+            )
+    
+    def get_context_messages(
+        self, 
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None
+    ) -> Tuple[List[Dict[str, Any]], bool]:
+        """Get current conversation messages for context with intelligent windowing.
+        
+        Args:
+            model: Model name for context limits
+            max_tokens: Maximum token limit
+            
+        Returns:
+            Tuple of (messages, was_truncated)
+        """
+        if self.current_session_id:
+            # Use session manager's context windowing
+            return self.manager.get_session_context(
+                self.current_session_id,
+                model=model,
+                max_tokens=max_tokens
+            )
+        else:
+            # Return current messages without windowing
+            return self.current_messages, False
+    
+    def get_loaded_messages_for_cli(self) -> List:
+        """Get loaded messages in CLI format (Message objects) for conversation history.
+        
+        Returns:
+            List of Message objects for CLI conversation history, or empty list if no session loaded.
+        """
+        if not hasattr(self, '_messages_loaded') or not self._messages_loaded:
+            return []
+        
+        from coda.providers import Message, Role
+        
+        cli_messages = []
+        for msg in self.current_messages:
+            # Convert role string to Role enum
+            role_map = {
+                'user': Role.USER,
+                'assistant': Role.ASSISTANT, 
+                'system': Role.SYSTEM,
+                'tool': Role.USER  # Fallback for tool messages
+            }
+            role = role_map.get(msg['role'], Role.USER)
+            
+            cli_messages.append(Message(
+                role=role,
+                content=msg['content']
+            ))
+        
+        # Reset the flag after providing messages
+        self._messages_loaded = False
+        
+        return cli_messages
+    
+    def was_conversation_cleared(self) -> bool:
+        """Check if conversation was cleared and reset the flag.
+        
+        Returns:
+            True if conversation was cleared since last check.
+        """
+        if hasattr(self, '_conversation_cleared') and self._conversation_cleared:
+            self._conversation_cleared = False
+            return True
+        return False
+    
+    def clear_conversation(self):
+        """Clear current conversation."""
+        self.current_messages = []
+        self.current_session_id = None
+        self._messages_loaded = False
+        self._conversation_cleared = True

--- a/coda/session/context.py
+++ b/coda/session/context.py
@@ -42,6 +42,7 @@ class ContextManager:
             "gpt-4": 8192,
             "gpt-4-32k": 32768,
             "gpt-4-turbo": 128000,
+            "gpt-4-turbo-preview": 128000,
             "gpt-3.5-turbo": 4096,
             "gpt-3.5-turbo-16k": 16384,
             
@@ -187,7 +188,10 @@ class ContextManager:
         # Sort by original order (assuming messages have indices or timestamps)
         # For now, we'll maintain relative order
         
-        return optimized, True
+        # Check if any truncation occurred
+        was_truncated = len(optimized) < len(messages)
+        
+        return optimized, was_truncated
     
     def create_summary_message(
         self,

--- a/coda/session/context.py
+++ b/coda/session/context.py
@@ -1,0 +1,297 @@
+"""Context management for sessions with intelligent windowing."""
+
+from typing import List, Dict, Any, Optional, Tuple
+from dataclasses import dataclass
+import tiktoken
+
+
+@dataclass
+class ContextWindow:
+    """Represents a context window configuration."""
+    max_tokens: int
+    max_messages: int
+    preserve_system: bool = True
+    summarization_threshold: float = 0.8  # Summarize when 80% full
+
+
+class ContextManager:
+    """Manages context windowing and optimization for sessions."""
+    
+    def __init__(self, model: str = "gpt-3.5-turbo"):
+        """Initialize context manager.
+        
+        Args:
+            model: Model name for token counting
+        """
+        self.model = model
+        self._init_tokenizer()
+        
+        # Default context windows for different models
+        self.model_context_limits = {
+            # OCI GenAI models
+            "cohere.command-r-plus": 128000,
+            "cohere.command-r-16k": 16000,
+            "cohere.command": 4000,
+            "meta.llama-3.1-405b": 128000,
+            "meta.llama-3.1-70b": 128000,
+            "meta.llama-3.3-70b": 128000,
+            "meta.llama-4-3-90b": 131072,
+            "xai.grok-3": 131072,
+            
+            # OpenAI models
+            "gpt-4": 8192,
+            "gpt-4-32k": 32768,
+            "gpt-4-turbo": 128000,
+            "gpt-3.5-turbo": 4096,
+            "gpt-3.5-turbo-16k": 16384,
+            
+            # Default
+            "default": 4096
+        }
+    
+    def _init_tokenizer(self):
+        """Initialize the tokenizer for token counting."""
+        try:
+            # Try to use tiktoken for accurate token counting
+            self.tokenizer = tiktoken.encoding_for_model(self.model)
+        except:
+            # Fallback to cl100k_base encoding
+            try:
+                self.tokenizer = tiktoken.get_encoding("cl100k_base")
+            except:
+                # If tiktoken is not available, use approximate counting
+                self.tokenizer = None
+    
+    def count_tokens(self, text: str) -> int:
+        """Count tokens in text.
+        
+        Args:
+            text: Text to count tokens for
+            
+        Returns:
+            Approximate token count
+        """
+        if self.tokenizer:
+            return len(self.tokenizer.encode(text))
+        else:
+            # Approximate: 1 token ≈ 4 characters or 0.75 words
+            return max(len(text) // 4, len(text.split()) * 3 // 4)
+    
+    def count_message_tokens(self, message: Dict[str, Any]) -> int:
+        """Count tokens in a message.
+        
+        Args:
+            message: Message dict with role and content
+            
+        Returns:
+            Token count including overhead
+        """
+        # Message overhead (role, formatting)
+        overhead = 4
+        
+        # Count content tokens
+        content_tokens = self.count_tokens(message.get('content', ''))
+        
+        return overhead + content_tokens
+    
+    def get_model_context_limit(self, model: str) -> int:
+        """Get context limit for a model.
+        
+        Args:
+            model: Model name
+            
+        Returns:
+            Maximum context tokens
+        """
+        # Check exact match first
+        if model in self.model_context_limits:
+            return self.model_context_limits[model]
+        
+        # Check partial matches
+        model_lower = model.lower()
+        for key, limit in self.model_context_limits.items():
+            if key in model_lower or model_lower in key:
+                return limit
+        
+        # Default
+        return self.model_context_limits["default"]
+    
+    def optimize_context(
+        self,
+        messages: List[Dict[str, Any]],
+        model: str,
+        target_tokens: Optional[int] = None,
+        preserve_last_n: int = 10
+    ) -> Tuple[List[Dict[str, Any]], bool]:
+        """Optimize message context to fit within token limits.
+        
+        Args:
+            messages: List of message dicts
+            model: Model name
+            target_tokens: Target token limit (uses model default if None)
+            preserve_last_n: Number of recent messages to always preserve
+            
+        Returns:
+            Tuple of (optimized messages, was_truncated)
+        """
+        if not messages:
+            return [], False
+        
+        # Get token limit
+        if target_tokens is None:
+            model_limit = self.get_model_context_limit(model)
+            # Reserve 20% for response
+            target_tokens = int(model_limit * 0.8)
+        
+        # Count total tokens
+        total_tokens = sum(self.count_message_tokens(msg) for msg in messages)
+        
+        # If within limit, return as is
+        if total_tokens <= target_tokens:
+            return messages, False
+        
+        # Preserve system messages and recent messages
+        preserved_messages = []
+        preserved_tokens = 0
+        
+        # Always keep system messages
+        for msg in messages:
+            if msg.get('role') == 'system':
+                preserved_messages.append(msg)
+                preserved_tokens += self.count_message_tokens(msg)
+        
+        # Keep last N messages
+        recent_messages = []
+        recent_tokens = 0
+        for msg in reversed(messages[-preserve_last_n:]):
+            if msg.get('role') != 'system':
+                msg_tokens = self.count_message_tokens(msg)
+                if preserved_tokens + recent_tokens + msg_tokens <= target_tokens:
+                    recent_messages.insert(0, msg)
+                    recent_tokens += msg_tokens
+        
+        # Try to fit older messages
+        remaining_tokens = target_tokens - preserved_tokens - recent_tokens
+        older_messages = []
+        
+        for msg in messages[:-preserve_last_n]:
+            if msg.get('role') != 'system':
+                msg_tokens = self.count_message_tokens(msg)
+                if msg_tokens <= remaining_tokens:
+                    older_messages.append(msg)
+                    remaining_tokens -= msg_tokens
+        
+        # Combine messages
+        optimized = preserved_messages + older_messages + recent_messages
+        
+        # Sort by original order (assuming messages have indices or timestamps)
+        # For now, we'll maintain relative order
+        
+        return optimized, True
+    
+    def create_summary_message(
+        self,
+        messages: List[Dict[str, Any]],
+        max_tokens: int = 500
+    ) -> Dict[str, Any]:
+        """Create a summary message for truncated context.
+        
+        Args:
+            messages: Messages to summarize
+            max_tokens: Maximum tokens for summary
+            
+        Returns:
+            Summary message dict
+        """
+        # Count messages by role
+        role_counts = {}
+        for msg in messages:
+            role = msg.get('role', 'unknown')
+            role_counts[role] = role_counts.get(role, 0) + 1
+        
+        # Create summary
+        summary_parts = [
+            f"[Previous conversation summary: {len(messages)} messages",
+            f"({role_counts.get('user', 0)} user, {role_counts.get('assistant', 0)} assistant)]"
+        ]
+        
+        # Add key points from messages (simplified for now)
+        # In a real implementation, this could use LLM to summarize
+        key_topics = self._extract_key_topics(messages)
+        if key_topics:
+            summary_parts.append(f"Key topics: {', '.join(key_topics[:5])}")
+        
+        summary = " ".join(summary_parts)
+        
+        return {
+            'role': 'system',
+            'content': summary
+        }
+    
+    def _extract_key_topics(self, messages: List[Dict[str, Any]]) -> List[str]:
+        """Extract key topics from messages (simplified implementation).
+        
+        Args:
+            messages: Messages to analyze
+            
+        Returns:
+            List of key topics
+        """
+        # Simple keyword extraction
+        # In production, this could use NLP or LLM
+        topics = []
+        
+        # Common programming keywords to look for
+        keywords = [
+            'function', 'class', 'database', 'api', 'error', 'bug',
+            'feature', 'test', 'deploy', 'config', 'security', 'performance'
+        ]
+        
+        # Count keyword occurrences
+        keyword_counts = {}
+        for msg in messages:
+            content = msg.get('content', '').lower()
+            for keyword in keywords:
+                if keyword in content:
+                    keyword_counts[keyword] = keyword_counts.get(keyword, 0) + 1
+        
+        # Get top topics
+        sorted_topics = sorted(keyword_counts.items(), key=lambda x: x[1], reverse=True)
+        topics = [topic for topic, _ in sorted_topics[:5]]
+        
+        return topics
+    
+    def get_context_window(
+        self,
+        model: str,
+        mode: str = "balanced"
+    ) -> ContextWindow:
+        """Get recommended context window configuration.
+        
+        Args:
+            model: Model name
+            mode: Context mode (aggressive, balanced, conservative)
+            
+        Returns:
+            ContextWindow configuration
+        """
+        model_limit = self.get_model_context_limit(model)
+        
+        if mode == "aggressive":
+            # Use 90% of context
+            max_tokens = int(model_limit * 0.9)
+            max_messages = 100
+        elif mode == "conservative":
+            # Use 60% of context
+            max_tokens = int(model_limit * 0.6)
+            max_messages = 30
+        else:  # balanced
+            # Use 75% of context
+            max_tokens = int(model_limit * 0.75)
+            max_messages = 50
+        
+        return ContextWindow(
+            max_tokens=max_tokens,
+            max_messages=max_messages,
+            preserve_system=True
+        )

--- a/coda/session/database.py
+++ b/coda/session/database.py
@@ -1,0 +1,129 @@
+"""SQLite database connection and initialization for session management."""
+
+import os
+from pathlib import Path
+from typing import Optional
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import sessionmaker, Session as DBSession
+from sqlalchemy.pool import StaticPool
+
+from .models import Base
+
+
+class SessionDatabase:
+    """Manages SQLite database connections for session storage."""
+    
+    def __init__(self, db_path: Optional[Path] = None):
+        """Initialize database connection.
+        
+        Args:
+            db_path: Path to SQLite database file. If None, uses default location.
+        """
+        if db_path is None:
+            # Use XDG cache directory
+            cache_dir = Path(os.environ.get('XDG_CACHE_HOME', Path.home() / '.cache'))
+            db_path = cache_dir / 'coda' / 'sessions.db'
+        
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Create engine with connection pooling disabled for SQLite
+        self.engine = create_engine(
+            f'sqlite:///{self.db_path}',
+            connect_args={'check_same_thread': False},
+            poolclass=StaticPool,
+            echo=False
+        )
+        
+        # Enable foreign key support and WAL mode for better concurrency
+        @event.listens_for(self.engine, "connect")
+        def set_sqlite_pragma(dbapi_connection, connection_record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.close()
+        
+        # Create session factory
+        self.SessionLocal = sessionmaker(
+            autocommit=False,
+            autoflush=False,
+            bind=self.engine,
+            expire_on_commit=False  # Prevent objects from being expired after commit
+        )
+        
+        # Initialize database
+        self.init_db()
+    
+    def init_db(self):
+        """Create all tables if they don't exist."""
+        Base.metadata.create_all(bind=self.engine)
+        
+        # Create FTS5 virtual table for full-text search
+        with self.engine.connect() as conn:
+            # Check if FTS table exists
+            result = conn.execute(text(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'"
+            ))
+            if not result.fetchone():
+                conn.execute(text("""
+                    CREATE VIRTUAL TABLE messages_fts USING fts5(
+                        message_id UNINDEXED,
+                        session_id UNINDEXED,
+                        content,
+                        role UNINDEXED,
+                        tokenize='porter unicode61'
+                    )
+                """))
+                conn.commit()
+    
+    @contextmanager
+    def get_session(self) -> DBSession:
+        """Get a database session context manager.
+        
+        Yields:
+            SQLAlchemy session object.
+        """
+        session = self.SessionLocal()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+    
+    def close(self):
+        """Close database connections."""
+        self.engine.dispose()
+    
+    def vacuum(self):
+        """Optimize database by running VACUUM."""
+        with self.engine.connect() as conn:
+            conn.execute(text("VACUUM"))
+            conn.commit()
+    
+    def get_db_size(self) -> int:
+        """Get database file size in bytes."""
+        if self.db_path.exists():
+            return self.db_path.stat().st_size
+        return 0
+    
+    def backup(self, backup_path: Path):
+        """Create a backup of the database.
+        
+        Args:
+            backup_path: Path to save the backup.
+        """
+        import shutil
+        if self.db_path.exists():
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(self.db_path, backup_path)
+    
+    def clear_all(self):
+        """Clear all data from the database (use with caution)."""
+        Base.metadata.drop_all(bind=self.engine)
+        self.init_db()

--- a/coda/session/manager.py
+++ b/coda/session/manager.py
@@ -1,0 +1,612 @@
+"""Session management and persistence layer."""
+
+from datetime import datetime
+from typing import List, Optional, Dict, Any, Tuple
+from uuid import uuid4
+import json
+
+from sqlalchemy import and_, or_, desc, text
+from sqlalchemy.orm import Session as DBSession
+
+from .database import SessionDatabase
+from .models import Session, Message, Tag, MessageRole, SessionStatus, SearchIndex
+from .context import ContextManager
+
+
+class SessionManager:
+    """Manages session persistence and operations."""
+    
+    def __init__(self, database: Optional[SessionDatabase] = None):
+        """Initialize session manager.
+        
+        Args:
+            database: SessionDatabase instance. If None, creates a new one.
+        """
+        self.db = database or SessionDatabase()
+        self.context_manager = ContextManager()
+    
+    def create_session(
+        self,
+        name: str,
+        provider: str,
+        model: str,
+        mode: str = "general",
+        description: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        parent_id: Optional[str] = None,
+        branch_point_message_id: Optional[str] = None
+    ) -> Session:
+        """Create a new session.
+        
+        Args:
+            name: Session name
+            provider: LLM provider name
+            model: Model name
+            mode: Chat mode (general, code, debug, etc.)
+            description: Optional session description
+            system_prompt: Optional system prompt
+            config: Optional configuration dict
+            parent_id: Parent session ID for branching
+            branch_point_message_id: Message ID to branch from
+            
+        Returns:
+            Created session object
+        """
+        with self.db.get_session() as db:
+            session = Session(
+                id=str(uuid4()),
+                name=name,
+                provider=provider,
+                model=model,
+                mode=mode,
+                description=description,
+                system_prompt=system_prompt,
+                config=config or {},
+                parent_id=parent_id,
+                branch_point_message_id=branch_point_message_id
+            )
+            db.add(session)
+            db.commit()
+            db.refresh(session)
+            
+            # Store the ID before potential detachment
+            session_id = session.id
+            
+            # If branching, copy messages up to branch point
+            if parent_id and branch_point_message_id:
+                self._copy_messages_to_branch(db, parent_id, session_id, branch_point_message_id)
+            
+            # Return a fresh copy to avoid detachment issues
+            return db.query(Session).filter_by(id=session_id).first()
+    
+    def _copy_messages_to_branch(
+        self, 
+        db: DBSession,
+        parent_id: str,
+        new_session_id: str,
+        branch_point_message_id: str
+    ):
+        """Copy messages from parent session up to branch point."""
+        # Get branch point message sequence
+        branch_msg = db.query(Message).filter_by(id=branch_point_message_id).first()
+        if not branch_msg:
+            return
+        
+        # Copy all messages up to and including branch point
+        parent_messages = db.query(Message).filter(
+            and_(
+                Message.session_id == parent_id,
+                Message.sequence <= branch_msg.sequence
+            )
+        ).order_by(Message.sequence).all()
+        
+        for msg in parent_messages:
+            new_msg = Message(
+                session_id=new_session_id,
+                sequence=msg.sequence,
+                role=msg.role,
+                content=msg.content,
+                model=msg.model,
+                provider=msg.provider,
+                prompt_tokens=msg.prompt_tokens,
+                completion_tokens=msg.completion_tokens,
+                total_tokens=msg.total_tokens,
+                cost=msg.cost,
+                metadata=msg.metadata,
+                tool_calls=msg.tool_calls,
+                attachments=msg.attachments,
+                search_content=msg.search_content
+            )
+            db.add(new_msg)
+    
+    def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tool_calls: Optional[List[Dict[str, Any]]] = None,
+        attachments: Optional[List[Dict[str, Any]]] = None,
+        token_usage: Optional[Dict[str, int]] = None,
+        cost: Optional[float] = None
+    ) -> Message:
+        """Add a message to a session.
+        
+        Args:
+            session_id: Session ID
+            role: Message role (user, assistant, system, tool)
+            content: Message content
+            model: Model used for generation
+            provider: Provider used
+            metadata: Additional metadata
+            tool_calls: Tool invocations (for Phase 5)
+            attachments: File attachments
+            token_usage: Token usage dict with prompt_tokens, completion_tokens
+            cost: Message cost
+            
+        Returns:
+            Created message object
+        """
+        with self.db.get_session() as db:
+            # Get next sequence number
+            last_msg = db.query(Message).filter_by(
+                session_id=session_id
+            ).order_by(desc(Message.sequence)).first()
+            
+            sequence = (last_msg.sequence + 1) if last_msg else 1
+            
+            # Create message
+            message = Message(
+                session_id=session_id,
+                sequence=sequence,
+                role=role,
+                content=content,
+                model=model,
+                provider=provider,
+                message_metadata=metadata or {},
+                tool_calls=tool_calls,
+                attachments=attachments,
+                search_content=self._prepare_search_content(content),
+                prompt_tokens=token_usage.get('prompt_tokens') if token_usage else None,
+                completion_tokens=token_usage.get('completion_tokens') if token_usage else None,
+                total_tokens=token_usage.get('total_tokens') if token_usage else None,
+                cost=cost
+            )
+            db.add(message)
+            
+            # Update session statistics
+            session = db.query(Session).filter_by(id=session_id).first()
+            if session:
+                session.message_count += 1
+                session.accessed_at = datetime.utcnow()
+                if token_usage and token_usage.get('total_tokens'):
+                    session.total_tokens += token_usage['total_tokens']
+                if cost:
+                    session.total_cost += cost
+            
+            # Update FTS index
+            db.execute(text("""
+                INSERT INTO messages_fts (message_id, session_id, content, role)
+                VALUES (:msg_id, :session_id, :content, :role)
+            """), {
+                'msg_id': message.id,
+                'session_id': session_id,
+                'content': content,
+                'role': role
+            })
+            
+            db.commit()
+            db.refresh(message)
+            
+            # Store the ID to avoid detachment issues
+            message_id = message.id
+            
+            # Return a fresh copy
+            return db.query(Message).filter_by(id=message_id).first()
+    
+    def _prepare_search_content(self, content: str) -> str:
+        """Prepare content for full-text search."""
+        # Basic preprocessing - can be enhanced later
+        return content.lower().strip()
+    
+    def get_session(self, session_id: str) -> Optional[Session]:
+        """Get a session by ID."""
+        with self.db.get_session() as db:
+            return db.query(Session).filter_by(id=session_id).first()
+    
+    def get_active_sessions(
+        self, 
+        limit: int = 50,
+        offset: int = 0
+    ) -> List[Session]:
+        """Get active sessions ordered by last access."""
+        with self.db.get_session() as db:
+            return db.query(Session).filter_by(
+                status=SessionStatus.ACTIVE.value
+            ).order_by(
+                desc(Session.accessed_at)
+            ).limit(limit).offset(offset).all()
+    
+    def get_messages(
+        self,
+        session_id: str,
+        limit: Optional[int] = None,
+        offset: int = 0
+    ) -> List[Message]:
+        """Get messages for a session."""
+        with self.db.get_session() as db:
+            query = db.query(Message).filter_by(
+                session_id=session_id
+            ).order_by(Message.sequence)
+            
+            if limit:
+                query = query.limit(limit).offset(offset)
+            
+            return query.all()
+    
+    def search_sessions(
+        self,
+        query: str,
+        limit: int = 20
+    ) -> List[Tuple[Session, List[Message]]]:
+        """Search sessions and messages using full-text search.
+        
+        Args:
+            query: Search query
+            limit: Maximum results
+            
+        Returns:
+            List of (session, matching_messages) tuples
+        """
+        with self.db.get_session() as db:
+            # Search in messages using FTS
+            results = db.execute(text("""
+                SELECT DISTINCT session_id, message_id
+                FROM messages_fts
+                WHERE messages_fts MATCH :query
+                ORDER BY rank
+                LIMIT :limit
+            """), {'query': query, 'limit': limit}).fetchall()
+            
+            if not results:
+                return []
+            
+            # Group by session
+            session_messages = {}
+            for session_id, message_id in results:
+                if session_id not in session_messages:
+                    session_messages[session_id] = []
+                session_messages[session_id].append(message_id)
+            
+            # Fetch sessions and messages
+            result_list = []
+            for session_id, message_ids in session_messages.items():
+                session = db.query(Session).filter_by(id=session_id).first()
+                if session and session.status == SessionStatus.ACTIVE.value:
+                    messages = db.query(Message).filter(
+                        Message.id.in_(message_ids)
+                    ).order_by(Message.sequence).all()
+                    result_list.append((session, messages))
+            
+            return result_list
+    
+    def delete_session(self, session_id: str, hard_delete: bool = False):
+        """Delete or archive a session.
+        
+        Args:
+            session_id: Session ID
+            hard_delete: If True, permanently deletes. Otherwise marks as deleted.
+        """
+        with self.db.get_session() as db:
+            session = db.query(Session).filter_by(id=session_id).first()
+            if not session:
+                return
+            
+            if hard_delete:
+                # Delete from FTS index
+                db.execute(text("""
+                    DELETE FROM messages_fts 
+                    WHERE session_id = :session_id
+                """), {'session_id': session_id})
+                
+                # Delete session (cascades to messages)
+                db.delete(session)
+            else:
+                # Soft delete
+                session.status = SessionStatus.DELETED.value
+            
+            db.commit()
+    
+    def archive_session(self, session_id: str):
+        """Archive a session."""
+        with self.db.get_session() as db:
+            session = db.query(Session).filter_by(id=session_id).first()
+            if session:
+                session.status = SessionStatus.ARCHIVED.value
+                db.commit()
+    
+    def update_session(
+        self,
+        session_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        config: Optional[Dict[str, Any]] = None
+    ):
+        """Update session metadata.
+        
+        Args:
+            session_id: Session ID
+            name: New name
+            description: New description
+            tags: List of tag names
+            config: Updated configuration
+        """
+        with self.db.get_session() as db:
+            session = db.query(Session).filter_by(id=session_id).first()
+            if not session:
+                return
+            
+            if name is not None:
+                session.name = name
+            if description is not None:
+                session.description = description
+            if config is not None:
+                session.config = config
+            
+            if tags is not None:
+                # Clear existing tags
+                session.tags.clear()
+                
+                # Add new tags
+                for tag_name in tags:
+                    tag = db.query(Tag).filter_by(name=tag_name).first()
+                    if not tag:
+                        tag = Tag(name=tag_name)
+                        db.add(tag)
+                    session.tags.append(tag)
+            
+            session.updated_at = datetime.utcnow()
+            db.commit()
+    
+    def get_session_context(
+        self,
+        session_id: str,
+        max_messages: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        model: Optional[str] = None,
+        mode: str = "balanced"
+    ) -> Tuple[List[Dict[str, Any]], bool]:
+        """Get session messages formatted for LLM context with intelligent windowing.
+        
+        Args:
+            session_id: Session ID
+            max_messages: Maximum number of recent messages
+            max_tokens: Maximum total tokens
+            model: Model name for context limits
+            mode: Context mode (aggressive, balanced, conservative)
+            
+        Returns:
+            Tuple of (message list, was_truncated)
+        """
+        session = self.get_session(session_id)
+        if not session:
+            return [], False
+        
+        messages = self.get_messages(session_id)
+        
+        # Convert to LLM format
+        context = []
+        for msg in messages:
+            msg_dict = {
+                'role': msg.role,
+                'content': msg.content
+            }
+            context.append(msg_dict)
+        
+        # Apply message limit if specified
+        if max_messages and len(context) > max_messages:
+            context = context[-max_messages:]
+        
+        # Use context manager for intelligent windowing
+        if model or max_tokens:
+            model_name = model or session.model
+            context, was_truncated = self.context_manager.optimize_context(
+                context,
+                model_name,
+                target_tokens=max_tokens,
+                preserve_last_n=10
+            )
+            
+            # Add summary if truncated
+            if was_truncated and len(messages) > len(context):
+                truncated_messages = messages[:len(messages) - len(context)]
+                summary = self.context_manager.create_summary_message(
+                    [{'role': m.role, 'content': m.content} for m in truncated_messages]
+                )
+                context.insert(0, summary)
+            
+            return context, was_truncated
+        
+        return context, False
+    
+    def export_session(
+        self,
+        session_id: str,
+        format: str = 'json'
+    ) -> str:
+        """Export a session in various formats.
+        
+        Args:
+            session_id: Session ID
+            format: Export format (json, markdown, txt, html)
+            
+        Returns:
+            Exported content as string
+        """
+        session = self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+        
+        messages = self.get_messages(session_id)
+        
+        if format == 'json':
+            return self._export_json(session, messages)
+        elif format == 'markdown':
+            return self._export_markdown(session, messages)
+        elif format == 'txt':
+            return self._export_txt(session, messages)
+        elif format == 'html':
+            return self._export_html(session, messages)
+        else:
+            raise ValueError(f"Unsupported export format: {format}")
+    
+    def _export_json(self, session: Session, messages: List[Message]) -> str:
+        """Export as JSON."""
+        data = {
+            'session': {
+                'id': session.id,
+                'name': session.name,
+                'description': session.description,
+                'provider': session.provider,
+                'model': session.model,
+                'mode': session.mode,
+                'created_at': session.created_at.isoformat(),
+                'updated_at': session.updated_at.isoformat(),
+                'message_count': session.message_count,
+                'total_tokens': session.total_tokens,
+                'total_cost': session.total_cost,
+                'config': session.config
+            },
+            'messages': [
+                {
+                    'sequence': msg.sequence,
+                    'role': msg.role,
+                    'content': msg.content,
+                    'created_at': msg.created_at.isoformat(),
+                    'model': msg.model,
+                    'provider': msg.provider,
+                    'tokens': {
+                        'prompt': msg.prompt_tokens,
+                        'completion': msg.completion_tokens,
+                        'total': msg.total_tokens
+                    },
+                    'cost': msg.cost,
+                    'metadata': msg.message_metadata,
+                    'tool_calls': msg.tool_calls,
+                    'attachments': msg.attachments
+                }
+                for msg in messages
+            ]
+        }
+        return json.dumps(data, indent=2)
+    
+    def _export_markdown(self, session: Session, messages: List[Message]) -> str:
+        """Export as Markdown."""
+        lines = [
+            f"# {session.name}",
+            "",
+            f"**Provider:** {session.provider}  ",
+            f"**Model:** {session.model}  ",
+            f"**Mode:** {session.mode}  ",
+            f"**Created:** {session.created_at.strftime('%Y-%m-%d %H:%M:%S')}  ",
+            f"**Messages:** {session.message_count}  ",
+            f"**Total Tokens:** {session.total_tokens}  ",
+            ""
+        ]
+        
+        if session.description:
+            lines.extend([f"{session.description}", ""])
+        
+        lines.append("---")
+        lines.append("")
+        
+        for msg in messages:
+            role_emoji = {
+                'user': '👤',
+                'assistant': '🤖',
+                'system': '⚙️',
+                'tool': '🔧'
+            }.get(msg.role, '❓')
+            
+            lines.append(f"### {role_emoji} {msg.role.title()}")
+            lines.append(f"*{msg.created_at.strftime('%Y-%m-%d %H:%M:%S')}*")
+            lines.append("")
+            lines.append(msg.content)
+            lines.append("")
+            
+            if msg.tool_calls:
+                lines.append("**Tool Calls:**")
+                lines.append("```json")
+                lines.append(json.dumps(msg.tool_calls, indent=2))
+                lines.append("```")
+                lines.append("")
+        
+        return "\n".join(lines)
+    
+    def _export_txt(self, session: Session, messages: List[Message]) -> str:
+        """Export as plain text."""
+        lines = [
+            f"Session: {session.name}",
+            f"Provider: {session.provider}",
+            f"Model: {session.model}",
+            f"Created: {session.created_at.strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Messages: {session.message_count}",
+            "=" * 80,
+            ""
+        ]
+        
+        for msg in messages:
+            lines.append(f"[{msg.role.upper()}] {msg.created_at.strftime('%H:%M:%S')}")
+            lines.append(msg.content)
+            lines.append("")
+        
+        return "\n".join(lines)
+    
+    def _export_html(self, session: Session, messages: List[Message]) -> str:
+        """Export as HTML."""
+        html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{session.name}</title>
+    <style>
+        body {{ font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }}
+        .message {{ margin: 20px 0; padding: 15px; border-radius: 8px; }}
+        .user {{ background-color: #e3f2fd; }}
+        .assistant {{ background-color: #f5f5f5; }}
+        .system {{ background-color: #fff3e0; }}
+        .tool {{ background-color: #f3e5f5; }}
+        .timestamp {{ color: #666; font-size: 0.9em; }}
+        .metadata {{ margin-top: 10px; font-size: 0.85em; color: #666; }}
+        pre {{ background-color: #f5f5f5; padding: 10px; border-radius: 4px; overflow-x: auto; }}
+    </style>
+</head>
+<body>
+    <h1>{session.name}</h1>
+    <p><strong>Provider:</strong> {session.provider} | <strong>Model:</strong> {session.model}</p>
+    <p><strong>Created:</strong> {session.created_at.strftime('%Y-%m-%d %H:%M:%S')}</p>
+    <hr>
+"""
+        
+        for msg in messages:
+            html += f"""
+    <div class="message {msg.role}">
+        <strong>{msg.role.title()}</strong>
+        <span class="timestamp">{msg.created_at.strftime('%H:%M:%S')}</span>
+        <div>{msg.content.replace(chr(10), '<br>')}</div>
+"""
+            if msg.metadata or msg.tool_calls:
+                html += '<div class="metadata">'
+                if msg.tool_calls:
+                    html += f'<pre>{json.dumps(msg.tool_calls, indent=2)}</pre>'
+                html += '</div>'
+            html += '    </div>\n'
+        
+        html += """
+</body>
+</html>"""
+        return html

--- a/coda/session/manager.py
+++ b/coda/session/manager.py
@@ -214,8 +214,13 @@ class SessionManager:
     
     def get_session(self, session_id: str) -> Optional[Session]:
         """Get a session by ID."""
+        from sqlalchemy.orm import joinedload
         with self.db.get_session() as db:
-            return db.query(Session).filter_by(id=session_id).first()
+            session = db.query(Session).options(joinedload(Session.tags)).filter_by(id=session_id).first()
+            if session:
+                # Access tags to ensure they're loaded
+                _ = session.tags
+            return session
     
     def get_active_sessions(
         self, 

--- a/coda/session/models.py
+++ b/coda/session/models.py
@@ -35,7 +35,8 @@ session_tags = Table(
     'session_tags',
     Base.metadata,
     Column('session_id', String, ForeignKey('sessions.id'), primary_key=True),
-    Column('tag_id', String, ForeignKey('tags.id'), primary_key=True)
+    Column('tag_id', String, ForeignKey('tags.id'), primary_key=True),
+    Index('idx_session_tags_tag', 'tag_id', 'session_id'),  # For tag-based lookups
 )
 
 
@@ -84,6 +85,10 @@ class Session(Base):
         Index('idx_session_updated', 'updated_at'),
         Index('idx_session_status', 'status'),
         Index('idx_session_provider_model', 'provider', 'model'),
+        Index('idx_session_created', 'created_at'),  # For /session last queries
+        Index('idx_session_accessed', 'accessed_at'),  # For access-based ordering
+        Index('idx_session_name', 'name'),  # For name-based lookups
+        Index('idx_session_parent', 'parent_id'),  # For branch navigation
     )
 
 

--- a/coda/session/models.py
+++ b/coda/session/models.py
@@ -1,0 +1,182 @@
+"""Session data models using SQLAlchemy."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional, Dict, Any, List
+from uuid import uuid4
+
+from sqlalchemy import (
+    Column, String, Text, DateTime, Boolean, Integer, 
+    ForeignKey, JSON, Float, Index, Table
+)
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+Base = declarative_base()
+
+
+class MessageRole(Enum):
+    """Message role enumeration."""
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    TOOL = "tool"
+
+
+class SessionStatus(Enum):
+    """Session status enumeration."""
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+    DELETED = "deleted"
+
+
+session_tags = Table(
+    'session_tags',
+    Base.metadata,
+    Column('session_id', String, ForeignKey('sessions.id'), primary_key=True),
+    Column('tag_id', String, ForeignKey('tags.id'), primary_key=True)
+)
+
+
+class Session(Base):
+    """Represents a conversation session."""
+    __tablename__ = 'sessions'
+    
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    name = Column(String, nullable=False)
+    description = Column(Text)
+    provider = Column(String, nullable=False)
+    model = Column(String, nullable=False)
+    mode = Column(String, default="general")
+    
+    # Timestamps
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    accessed_at = Column(DateTime, default=datetime.utcnow)
+    
+    # Session metadata
+    status = Column(String, default=SessionStatus.ACTIVE.value)
+    parent_id = Column(String, ForeignKey('sessions.id'), nullable=True)
+    branch_point_message_id = Column(String, ForeignKey('messages.id'), nullable=True)
+    
+    # Configuration
+    system_prompt = Column(Text)
+    temperature = Column(Float)
+    max_tokens = Column(Integer)
+    config = Column(JSON, default=dict)
+    
+    # Statistics
+    message_count = Column(Integer, default=0)
+    total_tokens = Column(Integer, default=0)
+    total_cost = Column(Float, default=0.0)
+    
+    # Relationships
+    messages = relationship("Message", back_populates="session", 
+                          foreign_keys="Message.session_id",
+                          cascade="all, delete-orphan",
+                          order_by="Message.sequence")
+    tags = relationship("Tag", secondary=session_tags, back_populates="sessions")
+    parent = relationship("Session", remote_side=[id], backref="branches")
+    
+    # Indexes
+    __table_args__ = (
+        Index('idx_session_updated', 'updated_at'),
+        Index('idx_session_status', 'status'),
+        Index('idx_session_provider_model', 'provider', 'model'),
+    )
+
+
+class Message(Base):
+    """Represents a message in a session."""
+    __tablename__ = 'messages'
+    
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    session_id = Column(String, ForeignKey('sessions.id'), nullable=False)
+    sequence = Column(Integer, nullable=False)
+    
+    # Message content
+    role = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    
+    # Metadata
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    model = Column(String)
+    provider = Column(String)
+    
+    # Token usage
+    prompt_tokens = Column(Integer)
+    completion_tokens = Column(Integer)
+    total_tokens = Column(Integer)
+    cost = Column(Float)
+    
+    # Additional data
+    message_metadata = Column(JSON, default=dict)
+    tool_calls = Column(JSON)  # For Phase 5 integration
+    attachments = Column(JSON)  # File references, images, etc
+    
+    # Error tracking
+    error = Column(Text)
+    error_type = Column(String)
+    
+    # Relationships
+    session = relationship("Session", back_populates="messages", 
+                         foreign_keys=[session_id])
+    
+    # Full-text search
+    search_content = Column(Text)  # Preprocessed content for FTS
+    
+    # Indexes
+    __table_args__ = (
+        Index('idx_message_session_seq', 'session_id', 'sequence'),
+        Index('idx_message_created', 'created_at'),
+        Index('idx_message_role', 'role'),
+    )
+
+
+class Tag(Base):
+    """Tags for organizing sessions."""
+    __tablename__ = 'tags'
+    
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    name = Column(String, unique=True, nullable=False)
+    color = Column(String)  # Hex color code
+    created_at = Column(DateTime, default=datetime.utcnow)
+    
+    # Relationships
+    sessions = relationship("Session", secondary=session_tags, back_populates="tags")
+
+
+class Attachment(Base):
+    """File attachments for messages."""
+    __tablename__ = 'attachments'
+    
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    message_id = Column(String, ForeignKey('messages.id'), nullable=False)
+    filename = Column(String, nullable=False)
+    content_type = Column(String)
+    size = Column(Integer)
+    path = Column(String)  # Local file path or URL
+    attachment_metadata = Column(JSON, default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    
+    # Relationships
+    message = relationship("Message", backref="attachment_records")
+
+
+class SearchIndex(Base):
+    """Full-text search index for sessions and messages."""
+    __tablename__ = 'search_index'
+    
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    entity_type = Column(String, nullable=False)  # 'session' or 'message'
+    entity_id = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    search_metadata = Column(JSON, default=dict)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    
+    # Indexes
+    __table_args__ = (
+        Index('idx_search_entity', 'entity_type', 'entity_id'),
+        Index('idx_search_updated', 'updated_at'),
+    )

--- a/docs/mock_provider_reference.md
+++ b/docs/mock_provider_reference.md
@@ -1,0 +1,233 @@
+# Mock Provider Reference for Coding Agents
+
+This document describes the MockProvider's behavior patterns for automated testing and AI agent reference.
+
+## Overview
+
+The MockProvider (`coda.providers.MockProvider`) is a test provider that simulates realistic AI assistant behavior without external API dependencies. It provides predictable, context-aware responses based on pattern matching and conversation history.
+
+## Models Available
+
+- `mock-echo`: Context-aware responses with fallback echoing
+- `mock-smart`: Same behavior as mock-echo (alias for testing)
+
+## Response Patterns
+
+The MockProvider processes messages in the following priority order:
+
+### 1. Memory Questions (Highest Priority)
+
+**Triggers**: "what were we discussing", "talking about"
+**Behavior**: Analyzes previous messages (excluding current) for topics
+
+```python
+# Single message - no context
+messages = [Message(role=Role.USER, content="What were we discussing?")]
+# Response: "I don't see any previous conversation to reference."
+
+# With conversation history
+messages = [
+    Message(role=Role.USER, content="What is Python?"),
+    Message(role=Role.ASSISTANT, content="Python is a language"),
+    Message(role=Role.USER, content="What were we discussing?")
+]
+# Response: "We were discussing: Python programming. What would you like to know more about?"
+```
+
+### 2. Programming Topics
+
+**Python Questions**:
+```python
+# Basic Python question
+Message(content="What is Python?")
+# Response: "Python is a high-level programming language known for its simplicity and readability."
+
+# Python with decorator context
+messages = [
+    Message(content="Tell me about decorators"),
+    Message(content="What is Python?")
+]
+# Response: "Yes, we were discussing Python decorators. They are functions that modify other functions, using the @decorator syntax."
+```
+
+**JavaScript Questions**:
+```python
+Message(content="Tell me about JavaScript")
+# Response: "JavaScript is a dynamic programming language primarily used for web development."
+```
+
+**Decorator Questions**:
+```python
+# Single message
+Message(content="What are decorators?")
+# Response: "Decorators in Python are a way to modify functions using the @ syntax. For example: @property or @staticmethod."
+
+# With previous decorator context
+messages = [
+    Message(content="Tell me about decorators"),
+    Message(content="What are Python decorators?")
+]
+# Response: "Yes, we were discussing Python decorators. They are functions that modify other functions, using the @decorator syntax."
+```
+
+### 3. Greetings and Help
+
+```python
+Message(content="Hello")
+# Response: "Hello! How can I help you today?"
+
+Message(content="Help me")
+# Response: "I'm a mock AI assistant. I can help you test session management features."
+```
+
+### 4. Echo Fallback (Lowest Priority)
+
+For unrecognized input, provides contextual echo:
+
+```python
+# Single message
+Message(content="The weather is nice")
+# Response: "You said: 'The weather is nice'"
+
+# In conversation
+messages = [
+    Message(content="First question"),
+    Message(content="Random input")  # Current message
+]
+# Response: "You said: 'Random input' This is message #2 in our conversation. Earlier you asked about: 'First question...'"
+```
+
+## Topic Recognition
+
+The MockProvider recognizes these topics in conversation history:
+
+- **"python"** → "Python programming"
+- **"decorator"** → "Python decorators" 
+- **"javascript"** → "JavaScript"
+
+## Testing Patterns
+
+### Test Conversation Continuity
+
+```python
+def test_session_memory():
+    provider = MockProvider()
+    
+    # Build conversation
+    messages = [
+        Message(role=Role.USER, content="What is Python?"),
+        Message(role=Role.ASSISTANT, content="Python is a language"),
+        Message(role=Role.USER, content="Tell me about decorators"),
+        Message(role=Role.ASSISTANT, content="Decorators modify functions")
+    ]
+    
+    # Test memory
+    messages.append(Message(role=Role.USER, content="What were we discussing?"))
+    response = provider.chat(messages, "mock-echo")
+    
+    # Should reference previous topics
+    assert "Python" in response or "decorator" in response
+```
+
+### Test Memory Isolation
+
+```python
+def test_no_false_memory():
+    provider = MockProvider()
+    
+    # Single message with topic keywords but no context
+    messages = [Message(role=Role.USER, content="What were we discussing about Python?")]
+    response = provider.chat(messages, "mock-echo")
+    
+    # Should NOT assume context from keywords in current message
+    assert "I don't see any previous conversation" in response
+```
+
+### Test Context Awareness
+
+```python
+def test_context_building():
+    provider = MockProvider()
+    
+    # Progressive conversation
+    msg1 = [Message(role=Role.USER, content="What is Python?")]
+    response1 = provider.chat(msg1, "mock-echo")
+    assert "high-level programming language" in response1
+    
+    # Add context about decorators
+    msg2 = msg1 + [
+        Message(role=Role.ASSISTANT, content=response1),
+        Message(role=Role.USER, content="What is Python?")  # Same question with context
+    ]
+    response2 = provider.chat(msg2, "mock-echo")
+    # Should give same basic response since no decorator context yet
+    assert "high-level programming language" in response2
+```
+
+## Key Testing Use Cases
+
+### ✅ Session Management Tests
+- **Save/Load Verification**: Test that conversation context is preserved
+- **Memory Restoration**: Verify AI remembers previous topics after session load
+- **Context Isolation**: Ensure cleared conversations have no memory
+
+### ✅ Conversation Flow Tests
+- **Topic Progression**: Test how conversations build context over time
+- **Memory Questions**: Verify "what were we discussing" works correctly
+- **Context Switching**: Test branching conversations
+
+### ✅ Provider Interface Tests
+- **Model Listing**: Test `list_models()` returns mock models
+- **Streaming**: Test `chat_stream()` yields word-by-word responses
+- **Async Support**: Test `achat()` and `achat_stream()` methods
+
+## Important Testing Notes
+
+### Memory Question Priority
+Memory questions ("what were we discussing") are processed BEFORE topic-specific responses. This prevents false positives where topic keywords in the memory question itself trigger topic responses.
+
+### Context Validation
+The provider only references topics from PREVIOUS messages, not the current message being processed. This ensures realistic memory behavior.
+
+### Predictable Responses
+Responses are deterministic based on input patterns, making them suitable for automated testing assertions.
+
+### No External Dependencies
+MockProvider works completely offline and requires no API keys or network access.
+
+## Example Test Template
+
+```python
+def test_mock_provider_behavior():
+    provider = MockProvider()
+    
+    # Test specific pattern
+    messages = [
+        Message(role=Role.USER, content="your test input"),
+        # Add more messages for context if needed
+    ]
+    
+    response = provider.chat(messages, "mock-echo")
+    
+    # Assert expected behavior
+    assert "expected content" in response
+    # or
+    assert any(keyword in response.lower() for keyword in ["keyword1", "keyword2"])
+```
+
+## Streaming Behavior
+
+The MockProvider also supports streaming responses:
+
+```python
+def test_streaming():
+    provider = MockProvider()
+    messages = [Message(role=Role.USER, content="Hello")]
+    
+    chunks = list(provider.chat_stream(messages, "mock-echo"))
+    full_response = "".join(chunk.content for chunk in chunks)
+    
+    assert full_response == "Hello! How can I help you today?"
+```
+
+This reference enables coding agents to write comprehensive tests that leverage the MockProvider's predictable behavior patterns while testing realistic conversation scenarios.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "cryptography>=3.4.7",
     "pygments>=2.19.2",
     "pyyaml>=6.0.1",
+    "tiktoken>=0.5.0",
 ]
 
 [project.scripts]

--- a/test_session_guide.md
+++ b/test_session_guide.md
@@ -1,0 +1,165 @@
+# Session Management Testing Guide
+
+## Quick Manual Test
+
+You can now test the session management functionality with the new **mock provider**:
+
+### 1. Start CLI with Mock Provider
+
+```bash
+uv run coda --provider mock
+```
+
+Select model `1` (mock-echo) when prompted.
+
+### 2. Test the Complete Workflow
+
+```bash
+# Start conversation
+Hello, can you help me with Python?
+
+# Continue conversation  
+What are decorators in Python?
+
+# Save the session
+/session save "Python Tutorial"
+# (Press Enter for empty description)
+
+# Add more to conversation
+Can you show me decorator examples?
+
+# List sessions to verify save
+/session list
+
+# Clear conversation
+/clear
+
+# Verify AI has no memory
+What were we discussing?
+# Should respond that no previous conversation exists
+
+# Load the saved session
+/session load "Python Tutorial"
+# Should see: "Restored X messages to conversation history"
+
+# Test that AI remembers the context
+What were we discussing about decorators?
+# Should reference the previous Python/decorator conversation!
+
+# Test session info
+/session info
+
+# Test export
+/export markdown
+
+# Test search
+/session search "Python"
+```
+
+### 3. Test Session Branching
+
+```bash
+# In the loaded session, create a branch
+/session branch "Advanced Python"
+
+# Continue with advanced topics
+Tell me about metaclasses in Python
+
+# Switch back to original
+/session load "Python Tutorial"
+
+# Verify original conversation is intact
+/session info
+```
+
+## Automated Tests
+
+### Run Comprehensive Tests
+
+```bash
+# Run all session tests
+uv run python -m pytest tests/session/ -v
+
+# Run specific integration test  
+uv run python -c "
+from tests.integration.test_session_integration import TestSessionEndToEnd
+test = TestSessionEndToEnd()
+test.test_complete_session_lifecycle()
+print('✅ Integration test passed!')
+"
+```
+
+### Test Mock Provider
+
+```bash
+# Test mock provider directly
+uv run python -c "
+from coda.providers import MockProvider, Message, Role
+
+provider = MockProvider()
+messages = [
+    Message(role=Role.USER, content='What is Python?'),
+    Message(role=Role.ASSISTANT, content='Python is a programming language'),
+    Message(role=Role.USER, content='What were we discussing?')
+]
+
+response = provider.chat(messages, 'mock-echo')
+print(f'Response: {response}')
+assert 'python' in response.lower()
+print('✅ Mock provider context test passed!')
+"
+```
+
+## Expected Behavior
+
+### ✅ Session Save/Load
+- **Save**: `/session save "name"` stores conversation in SQLite database
+- **Load**: `/session load "name"` restores conversation AND makes it available to AI
+- **Verification**: AI remembers previous conversation after loading
+
+### ✅ Context Continuity  
+- **Before Load**: AI has no memory of previous conversations
+- **After Load**: AI can reference and continue previous conversations
+- **Branching**: Create conversation branches from any point
+
+### ✅ Session Management
+- **List**: View all saved sessions with metadata
+- **Search**: Full-text search across all conversations  
+- **Export**: Export sessions in JSON, Markdown, HTML, or text format
+- **Info**: View detailed session information
+
+### ✅ Mock Provider Features
+- **Context Awareness**: Remembers conversation history
+- **Topic Recognition**: Recognizes Python, JavaScript, decorators, etc.
+- **Memory Questions**: Responds appropriately to "what were we discussing"
+- **Conversation Flow**: Maintains context across multiple turns
+
+## Troubleshooting
+
+### If Session Loading Doesn't Work
+1. Verify session was saved: `/session list`
+2. Check for error messages during load
+3. Verify database exists: `~/.cache/coda/sessions.db`
+4. Try with a fresh session
+
+### If AI Doesn't Remember Context
+1. Look for "Restored X messages to conversation history" message
+2. Verify the session contains the expected messages: `/session info`
+3. Check that you're using a conversation-aware provider (mock, oci_genai, etc.)
+
+### Mock Provider Benefits
+- **No External Dependencies**: Works offline, no API keys needed
+- **Predictable Responses**: Consistent behavior for testing
+- **Context Demonstration**: Clearly shows memory working
+- **Fast Testing**: Immediate responses for rapid iteration
+
+The mock provider is perfect for:
+- ✅ Testing session management features
+- ✅ Validating conversation continuity
+- ✅ Demonstrating the fix for session loading
+- ✅ CI/CD testing without external services
+- ✅ Development and debugging
+
+---
+
+**Result**: You now have comprehensive testing for the session management fix, including a mock provider that demonstrates conversation continuity working correctly! 🎯

--- a/tests/cli/test_interactive_cli.py
+++ b/tests/cli/test_interactive_cli.py
@@ -126,14 +126,14 @@ class TestInteractiveCLI:
         calls = [str(call) for call in cli.console.print.call_args_list]
         assert any("Available Commands" in str(call) for call in calls)
 
-        # Check that categories are shown
-        assert any("AI Settings" in str(call) for call in calls)
-        assert any("Session" in str(call) for call in calls)
-        assert any("System" in str(call) for call in calls)
-
-        # Check that all commands are mentioned
+        # Check that all commands are mentioned (registry format)
         for cmd_name in cli.commands:
             assert any(f"/{cmd_name}" in str(call) for call in calls)
+        
+        # Check specific commands are present
+        assert any("/help" in str(call) for call in calls)
+        assert any("/session" in str(call) for call in calls)
+        assert any("/export" in str(call) for call in calls)
 
     def test_exit_command(self, cli):
         """Test exit command."""
@@ -247,20 +247,27 @@ class TestInteractiveCLI:
         assert any("not supported in current mode" in str(call) for call in calls)
 
     def test_session_command(self, cli):
-        """Test session command (coming soon)."""
-        # Test without args
-        cli._cmd_session("")
+        """Test session command."""
+        # Mock the session commands to avoid console output issues
+        cli.session_commands.handle_session_command = Mock(return_value="Session help shown")
+        
+        # Test without args - should call session command handler
+        result = cli._cmd_session("")
 
+        # Verify the session command handler was called with empty args
+        cli.session_commands.handle_session_command.assert_called_with([])
+        
+        # Should print the result
         calls = [str(call) for call in cli.console.print.call_args_list]
-        assert any("Session Management" in str(call) for call in calls)
-        assert any("Coming soon" in str(call) for call in calls)
+        assert any("Session help shown" in str(call) for call in calls)
 
-        # Test with args
+        # Test with args - should pass to session command handler
         cli.console.reset_mock()
-        cli._cmd_session("save")
+        cli.session_commands.handle_session_command.reset_mock()
+        cli._cmd_session("save test")
 
-        calls = [str(call) for call in cli.console.print.call_args_list]
-        assert any("not implemented yet" in str(call) for call in calls)
+        # Verify the session command handler was called with the right args
+        cli.session_commands.handle_session_command.assert_called_with(["save", "test"])
 
     def test_theme_command(self, cli):
         """Test theme command (coming soon)."""
@@ -279,20 +286,27 @@ class TestInteractiveCLI:
         assert any("not implemented yet" in str(call) for call in calls)
 
     def test_export_command(self, cli):
-        """Test export command (coming soon)."""
-        # Test without args
-        cli._cmd_export("")
+        """Test export command."""
+        # Mock the export commands to avoid console output issues
+        cli.session_commands.handle_export_command = Mock(return_value="Export help shown")
+        
+        # Test without args - should call export command handler
+        result = cli._cmd_export("")
 
+        # Verify the export command handler was called with empty args
+        cli.session_commands.handle_export_command.assert_called_with([])
+        
+        # Should print the result
         calls = [str(call) for call in cli.console.print.call_args_list]
-        assert any("Export Options" in str(call) for call in calls)
-        assert any("Coming soon" in str(call) for call in calls)
+        assert any("Export help shown" in str(call) for call in calls)
 
-        # Test with args
+        # Test with args - should pass to export command handler
         cli.console.reset_mock()
+        cli.session_commands.handle_export_command.reset_mock()
         cli._cmd_export("markdown")
 
-        calls = [str(call) for call in cli.console.print.call_args_list]
-        assert any("not implemented yet" in str(call) for call in calls)
+        # Verify the export command handler was called with the right args
+        cli.session_commands.handle_export_command.assert_called_with(["markdown"])
 
     def test_tools_command(self, cli):
         """Test tools command (coming soon)."""

--- a/tests/cli/test_mode_integration.py
+++ b/tests/cli/test_mode_integration.py
@@ -175,20 +175,24 @@ class TestInteractiveModeIntegration:
         assert any("Already using oci_genai" in str(call) for call in calls)
 
     def test_interactive_coming_soon_commands(self, cli):
-        """Test coming soon commands show proper messages."""
-        # Session command
+        """Test that implemented and coming soon commands work correctly."""
+        # Mock session commands to avoid console output issues
+        cli.session_commands.handle_session_command = Mock(return_value="Session help")
+        
+        # Session command - now implemented
         cli._cmd_session("")
         calls = [str(call) for call in cli.console.print.call_args_list]
-        assert any("Session Management" in str(call) for call in calls)
-        assert any("Coming soon" in str(call) for call in calls)
+        # Session commands are now implemented, should show help
+        assert any("Session help" in str(call) for call in calls)
 
-        # Theme command
+        # Theme command - still coming soon
         cli.console.reset_mock()
         cli._cmd_theme("")
         calls = [str(call) for call in cli.console.print.call_args_list]
         assert any("Theme Settings" in str(call) for call in calls)
+        assert any("Coming soon" in str(call) for call in calls)
 
-        # Tools command
+        # Tools command - still coming soon
         cli.console.reset_mock()
         cli._cmd_tools("")
         calls = [str(call) for call in cli.console.print.call_args_list]

--- a/tests/cli/test_shared_help.py
+++ b/tests/cli/test_shared_help.py
@@ -107,9 +107,8 @@ class TestSharedHelp:
         """Test that help content is not duplicated."""
         print_command_help(mock_console)
 
-        # Count occurrences of unique strings
+        # Count occurrences of unique strings in registry format
         calls_str = str(mock_console.print.call_args_list)
-        assert calls_str.count("AI Settings:") == 1
-        assert calls_str.count("System:") == 1
+        assert calls_str.count("Available Commands:") == 1
         assert calls_str.count("/model") == 1
         assert calls_str.count("/help") == 1

--- a/tests/integration/test_autosave_mock_provider.py
+++ b/tests/integration/test_autosave_mock_provider.py
@@ -1,0 +1,290 @@
+"""Integration tests for auto-save functionality with MockProvider."""
+
+import tempfile
+from pathlib import Path
+import pytest
+from unittest.mock import Mock, patch
+
+from coda.session import SessionDatabase, SessionManager, SessionCommands
+from coda.providers import MockProvider, Message, Role
+
+
+class TestAutoSaveWithMockProvider:
+    """Test auto-save functionality with MockProvider conversations."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    @pytest.fixture
+    def session_manager(self, temp_db_path):
+        """Create session manager with temporary database."""
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        yield manager
+        db.close()
+    
+    @pytest.fixture
+    def mock_provider(self):
+        """Create mock provider for testing."""
+        return MockProvider()
+    
+    @pytest.fixture
+    def session_commands(self, session_manager):
+        """Create session commands instance."""
+        return SessionCommands(session_manager)
+    
+    def test_auto_save_with_python_conversation(self, session_commands, mock_provider):
+        """Test auto-save triggers with a Python programming conversation."""
+        # Simulate user asking about Python
+        session_commands.add_message(
+            role="user",
+            content="What is Python?",
+            metadata={
+                "mode": "general",
+                "provider": "mock",
+                "model": "mock-echo"
+            }
+        )
+        
+        # Get MockProvider response
+        messages = [Message(role=Role.USER, content="What is Python?")]
+        response = mock_provider.chat(messages, "mock-echo")
+        
+        # Add assistant response
+        session_commands.add_message(
+            role="assistant",
+            content=response,
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        # Verify auto-save triggered
+        assert session_commands.current_session_id is not None
+        
+        # Verify conversation was saved correctly
+        session = session_commands.manager.get_session(session_commands.current_session_id)
+        assert session.name.startswith("auto-")
+        
+        messages = session_commands.manager.get_messages(session.id)
+        assert len(messages) == 2
+        assert "high-level programming language" in messages[1].content
+    
+    def test_auto_save_preserves_conversation_memory(self, session_commands, mock_provider):
+        """Test that auto-saved sessions preserve conversation context."""
+        # Build a conversation about decorators
+        conversation_flow = [
+            ("Tell me about decorators", "user"),
+            (None, "assistant"),  # Will be filled by MockProvider
+            ("What is Python?", "user"),
+            (None, "assistant"),  # Will be filled by MockProvider
+            ("What were we discussing?", "user"),
+            (None, "assistant"),  # Will be filled by MockProvider
+        ]
+        
+        mock_messages = []
+        
+        for content, role in conversation_flow:
+            if role == "user":
+                # Add user message
+                session_commands.add_message(
+                    role="user",
+                    content=content,
+                    metadata={
+                        "mode": "general",
+                        "provider": "mock",
+                        "model": "mock-echo"
+                    }
+                )
+                mock_messages.append(Message(role=Role.USER, content=content))
+            else:
+                # Get MockProvider response
+                response = mock_provider.chat(mock_messages, "mock-echo")
+                
+                # Add assistant response
+                session_commands.add_message(
+                    role="assistant",
+                    content=response,
+                    metadata={
+                        "provider": "mock",
+                        "model": "mock-echo",
+                        "mode": "general"
+                    }
+                )
+                mock_messages.append(Message(role=Role.ASSISTANT, content=response))
+        
+        # Verify session was auto-saved
+        assert session_commands.current_session_id is not None
+        
+        # Load the session and verify memory
+        saved_messages = session_commands.manager.get_messages(session_commands.current_session_id)
+        assert len(saved_messages) == 6
+        
+        # The final response should mention previous topics
+        final_response = saved_messages[-1].content
+        assert "decorator" in final_response.lower() or "python" in final_response.lower()
+    
+    def test_auto_save_with_different_modes(self, session_commands, mock_provider):
+        """Test auto-save works with different developer modes."""
+        modes = ["code", "debug", "explain"]
+        
+        for mode in modes:
+            # Reset for each mode test
+            session_commands.current_session_id = None
+            session_commands.current_messages = []
+            session_commands._has_user_message = False
+            
+            # Add messages
+            session_commands.add_message(
+                role="user",
+                content="Hello",
+                metadata={
+                    "mode": mode,
+                    "provider": "mock",
+                    "model": "mock-echo"
+                }
+            )
+            
+            # Get MockProvider response
+            messages = [Message(role=Role.USER, content="Hello")]
+            response = mock_provider.chat(messages, "mock-echo")
+            
+            session_commands.add_message(
+                role="assistant",
+                content=response,
+                metadata={
+                    "provider": "mock",
+                    "model": "mock-echo",
+                    "mode": mode
+                }
+            )
+            
+            # Verify auto-save triggered
+            assert session_commands.current_session_id is not None
+            
+            # Verify mode was saved
+            session = session_commands.manager.get_session(session_commands.current_session_id)
+            assert session.mode == mode
+    
+    def test_no_auto_save_with_incomplete_exchange(self, session_commands, mock_provider):
+        """Test that auto-save doesn't trigger without complete exchange."""
+        # Only add user message
+        session_commands.add_message(
+            role="user",
+            content="What is Python?",
+            metadata={
+                "mode": "general",
+                "provider": "mock",
+                "model": "mock-echo"
+            }
+        )
+        
+        # No auto-save should occur
+        assert session_commands.current_session_id is None
+        
+        # Add another user message (still no assistant)
+        session_commands.add_message(
+            role="user",
+            content="Tell me more",
+            metadata={
+                "mode": "general",
+                "provider": "mock",
+                "model": "mock-echo"
+            }
+        )
+        
+        # Still no auto-save
+        assert session_commands.current_session_id is None
+    
+    def test_session_continuity_after_auto_save(self, session_commands, mock_provider):
+        """Test that conversation continues properly after auto-save."""
+        # Initial exchange to trigger auto-save
+        session_commands.add_message(
+            role="user",
+            content="What is Python?",
+            metadata={"mode": "general", "provider": "mock", "model": "mock-echo"}
+        )
+        
+        messages = [Message(role=Role.USER, content="What is Python?")]
+        response1 = mock_provider.chat(messages, "mock-echo")
+        
+        session_commands.add_message(
+            role="assistant",
+            content=response1,
+            metadata={"provider": "mock", "model": "mock-echo", "mode": "general"}
+        )
+        
+        # Capture session ID
+        session_id = session_commands.current_session_id
+        assert session_id is not None
+        
+        # Continue conversation
+        session_commands.add_message(
+            role="user",
+            content="What were we discussing?",
+            metadata={"mode": "general", "provider": "mock", "model": "mock-echo"}
+        )
+        
+        # Build full message history for MockProvider
+        messages = [
+            Message(role=Role.USER, content="What is Python?"),
+            Message(role=Role.ASSISTANT, content=response1),
+            Message(role=Role.USER, content="What were we discussing?")
+        ]
+        response2 = mock_provider.chat(messages, "mock-echo")
+        
+        session_commands.add_message(
+            role="assistant",
+            content=response2,
+            metadata={"provider": "mock", "model": "mock-echo", "mode": "general"}
+        )
+        
+        # Verify same session is used
+        assert session_commands.current_session_id == session_id
+        
+        # Verify memory response
+        assert "Python" in response2
+        
+        # Verify all messages saved
+        saved_messages = session_commands.manager.get_messages(session_id)
+        assert len(saved_messages) == 4
+    
+    @pytest.mark.asyncio
+    async def test_streaming_with_auto_save(self, session_commands, mock_provider):
+        """Test auto-save works with streaming responses."""
+        # Add user message
+        session_commands.add_message(
+            role="user",
+            content="Hello",
+            metadata={"mode": "general", "provider": "mock", "model": "mock-echo"}
+        )
+        
+        # Simulate streaming response collection
+        messages = [Message(role=Role.USER, content="Hello")]
+        chunks = []
+        async for chunk in mock_provider.achat_stream(messages, "mock-echo"):
+            chunks.append(chunk.content)
+        
+        full_response = "".join(chunks)
+        
+        # Add complete response
+        session_commands.add_message(
+            role="assistant",
+            content=full_response,
+            metadata={"provider": "mock", "model": "mock-echo", "mode": "general"}
+        )
+        
+        # Verify auto-save
+        assert session_commands.current_session_id is not None
+        
+        # Verify correct response saved
+        saved_messages = session_commands.manager.get_messages(session_commands.current_session_id)
+        assert saved_messages[1].content == "Hello! How can I help you today?"

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -1,0 +1,463 @@
+"""Integration tests for session management with mock provider."""
+
+import tempfile
+from pathlib import Path
+import pytest
+import asyncio
+from unittest.mock import Mock, patch, AsyncMock
+
+from coda.session import SessionDatabase, SessionManager, SessionCommands
+from coda.cli.interactive_cli import InteractiveCLI
+from coda.providers import MockProvider, ProviderFactory, Message, Role
+from coda.configuration import CodaConfig
+
+
+class TestSessionIntegration:
+    """Test complete session management integration."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    @pytest.fixture
+    def session_manager(self, temp_db_path):
+        """Create session manager with temporary database."""
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        yield manager
+        db.close()
+    
+    @pytest.fixture
+    def mock_provider(self):
+        """Create mock provider for testing."""
+        return MockProvider()
+    
+    @pytest.fixture
+    def cli_with_sessions(self, session_manager):
+        """Create CLI with session management."""
+        cli = InteractiveCLI()
+        cli.session_commands = SessionCommands(session_manager)
+        return cli
+    
+    def test_mock_provider_basic_functionality(self, mock_provider):
+        """Test that mock provider works correctly."""
+        # Test basic chat
+        messages = [Message(role=Role.USER, content="Hello")]
+        response = mock_provider.chat(messages, "mock-echo")
+        assert "Hello" in response
+        
+        # Test context awareness
+        messages.append(Message(role=Role.ASSISTANT, content=response))
+        messages.append(Message(role=Role.USER, content="What is Python?"))
+        
+        response2 = mock_provider.chat(messages, "mock-echo")
+        assert "Python" in response2
+        assert "programming language" in response2.lower()
+    
+    def test_mock_provider_conversation_memory(self, mock_provider):
+        """Test mock provider remembers conversation context."""
+        # Start conversation about Python
+        messages = [
+            Message(role=Role.USER, content="Tell me about Python"),
+            Message(role=Role.ASSISTANT, content="Python is a programming language"),
+            Message(role=Role.USER, content="What about decorators?"),
+            Message(role=Role.ASSISTANT, content="Decorators modify functions"),
+            Message(role=Role.USER, content="What were we discussing about decorators?")
+        ]
+        
+        response = mock_provider.chat(messages, "mock-echo")
+        assert "decorator" in response.lower()
+        assert "python" in response.lower()
+    
+    def test_session_save_and_load_complete_flow(self, session_manager, mock_provider):
+        """Test complete save/load flow with actual conversation."""
+        # Simulate a conversation
+        session = session_manager.create_session(
+            name="Python Discussion",
+            provider="mock",
+            model="mock-echo",
+            description="Testing session save/load"
+        )
+        
+        # Add conversation messages
+        session_manager.add_message(
+            session.id, "user", "What is Python?", 
+            metadata={"provider": "mock", "model": "mock-echo"}
+        )
+        session_manager.add_message(
+            session.id, "assistant", "Python is a programming language",
+            metadata={"provider": "mock", "model": "mock-echo"}
+        )
+        session_manager.add_message(
+            session.id, "user", "Tell me about decorators",
+            metadata={"provider": "mock", "model": "mock-echo"}
+        )
+        session_manager.add_message(
+            session.id, "assistant", "Decorators are functions that modify other functions",
+            metadata={"provider": "mock", "model": "mock-echo"}
+        )
+        
+        # Test context retrieval
+        context, truncated = session_manager.get_session_context(session.id)
+        assert len(context) == 4
+        assert not truncated
+        
+        # Test that context contains proper conversation flow
+        assert context[0]['role'] == 'user'
+        assert "Python" in context[0]['content']
+        assert context[1]['role'] == 'assistant'
+        assert context[2]['role'] == 'user'
+        assert "decorator" in context[2]['content']
+        assert context[3]['role'] == 'assistant'
+        
+        # Test context would work with mock provider
+        messages = [Message(role=Role(msg['role']), content=msg['content']) for msg in context]
+        
+        # Add new question about previous conversation
+        messages.append(Message(role=Role.USER, content="What were we discussing about decorators?"))
+        
+        # Mock provider should remember the context
+        response = mock_provider.chat(messages, "mock-echo")
+        assert "decorator" in response.lower()
+    
+    def test_session_commands_integration(self, session_manager):
+        """Test session commands with full integration."""
+        commands = SessionCommands(session_manager)
+        
+        # Simulate adding messages from CLI
+        commands.add_message('user', 'Hello, I need help with Python', {
+            'provider': 'mock',
+            'model': 'mock-echo',
+            'mode': 'general'
+        })
+        commands.add_message('assistant', 'Hello! I can help you with Python.', {
+            'provider': 'mock', 
+            'model': 'mock-echo'
+        })
+        
+        assert len(commands.current_messages) == 2
+        
+        # Mock user input for save command (avoid interactive prompts)
+        with patch('rich.prompt.Prompt.ask') as mock_prompt:
+            mock_prompt.side_effect = ["Test Session", "A test session"]
+            
+            # Save session
+            result = commands.handle_session_command(['save', 'Python Help Session'])
+            assert "Session saved" in result
+            assert commands.current_session_id is not None
+        
+        # Verify session was saved
+        saved_session = session_manager.get_session(commands.current_session_id)
+        assert saved_session.name == "Python Help Session"
+        
+        # Clear conversation
+        commands.clear_conversation()
+        assert len(commands.current_messages) == 0
+        assert commands.current_session_id is None
+        
+        # Load session back
+        commands._load_session(['Python Help Session'])
+        
+        # Verify messages were restored
+        assert len(commands.current_messages) == 2
+        assert commands.current_messages[0]['content'] == 'Hello, I need help with Python'
+        assert commands.current_messages[1]['content'] == 'Hello! I can help you with Python.'
+        
+        # Test CLI message conversion
+        commands._messages_loaded = True  # Simulate load flag
+        cli_messages = commands.get_loaded_messages_for_cli()
+        
+        assert len(cli_messages) == 2
+        assert cli_messages[0].role == Role.USER
+        assert cli_messages[1].role == Role.ASSISTANT
+    
+    def test_conversation_continuity_after_load(self, session_manager, mock_provider):
+        """Test that conversation context is properly restored for AI."""
+        # Create session with conversation about Python
+        session = session_manager.create_session(
+            name="Python Context Test",
+            provider="mock",
+            model="mock-echo"
+        )
+        
+        # Build conversation
+        conversation = [
+            ("user", "What is Python?"),
+            ("assistant", "Python is a high-level programming language"),
+            ("user", "Tell me about decorators"), 
+            ("assistant", "Decorators in Python are functions that modify other functions")
+        ]
+        
+        for role, content in conversation:
+            session_manager.add_message(session.id, role, content)
+        
+        # Get context as if loading session
+        context, _ = session_manager.get_session_context(session.id)
+        
+        # Convert to Message objects (as CLI would do)
+        messages = [Message(role=Role(msg['role']), content=msg['content']) for msg in context]
+        
+        # Add new question that requires context
+        messages.append(Message(role=Role.USER, content="What were we discussing about decorators?"))
+        
+        # Test that mock provider can answer based on context
+        response = mock_provider.chat(messages, "mock-echo")
+        
+        # Should reference previous conversation
+        assert "decorator" in response.lower()
+        assert "python" in response.lower() or "we were discussing" in response.lower()
+    
+    def test_session_branching_with_conversation_continuity(self, session_manager, mock_provider):
+        """Test session branching maintains proper conversation flow."""
+        # Create original session
+        session = session_manager.create_session(
+            name="Original Session",
+            provider="mock", 
+            model="mock-echo"
+        )
+        
+        # Add initial conversation
+        messages = [
+            session_manager.add_message(session.id, "user", "What is Python?"),
+            session_manager.add_message(session.id, "assistant", "Python is a programming language"),
+            session_manager.add_message(session.id, "user", "What about JavaScript?"),
+            session_manager.add_message(session.id, "assistant", "JavaScript is used for web development")
+        ]
+        
+        # Create branch from second message
+        branch = session_manager.create_session(
+            name="Python Focus Branch",
+            provider="mock",
+            model="mock-echo",
+            parent_id=session.id,
+            branch_point_message_id=messages[1].id
+        )
+        
+        # Verify branch has correct messages
+        branch_messages = session_manager.get_messages(branch.id)
+        assert len(branch_messages) == 2  # Up to branch point
+        assert branch_messages[0].content == "What is Python?"
+        assert branch_messages[1].content == "Python is a programming language"
+        
+        # Test that branch context works with AI
+        context, _ = session_manager.get_session_context(branch.id)
+        messages = [Message(role=Role(msg['role']), content=msg['content']) for msg in context]
+        
+        # Continue conversation in branch
+        messages.append(Message(role=Role.USER, content="Can you tell me more about Python decorators?"))
+        
+        response = mock_provider.chat(messages, "mock-echo")
+        assert "python" in response.lower()
+        assert "decorator" in response.lower()
+    
+    def test_export_and_conversation_reconstruction(self, session_manager):
+        """Test that exported sessions can be used to reconstruct conversations."""
+        # Create session with multi-turn conversation
+        session = session_manager.create_session(
+            name="Export Test Session",
+            provider="mock",
+            model="mock-echo"
+        )
+        
+        conversation_data = [
+            ("user", "Hello, I'm learning Python"),
+            ("assistant", "Great! I can help you learn Python."),
+            ("user", "What are decorators?"),
+            ("assistant", "Decorators are a way to modify functions in Python"),
+            ("user", "Can you show me an example?"),
+            ("assistant", "Sure! Here's a simple decorator: @property")
+        ]
+        
+        for role, content in conversation_data:
+            session_manager.add_message(session.id, role, content)
+        
+        # Export in different formats
+        json_export = session_manager.export_session(session.id, 'json')
+        md_export = session_manager.export_session(session.id, 'markdown')
+        
+        # Verify exports contain conversation
+        assert "learning Python" in json_export
+        assert "decorators" in json_export
+        assert "@property" in json_export
+        
+        assert "learning Python" in md_export
+        assert "decorators" in md_export
+        assert "👤 User" in md_export  # Markdown formatting
+        assert "🤖 Assistant" in md_export
+    
+    def test_full_cli_session_workflow(self, temp_db_path):
+        """Test complete CLI workflow with session management."""
+        # This test simulates the actual CLI workflow
+        
+        # Create components
+        db = SessionDatabase(temp_db_path)
+        session_manager = SessionManager(db)
+        session_commands = SessionCommands(session_manager)
+        
+        # Simulate CLI conversation state
+        cli_messages = []
+        
+        try:
+            # Step 1: Start conversation
+            user_msg = Message(role=Role.USER, content="What is Python?")
+            cli_messages.append(user_msg)
+            
+            # Simulate session commands tracking
+            session_commands.add_message('user', 'What is Python?', {
+                'provider': 'mock', 'model': 'mock-echo'
+            })
+            
+            # Simulate AI response
+            ai_response = "Python is a programming language"
+            assistant_msg = Message(role=Role.ASSISTANT, content=ai_response)
+            cli_messages.append(assistant_msg)
+            
+            session_commands.add_message('assistant', ai_response, {
+                'provider': 'mock', 'model': 'mock-echo'
+            })
+            
+            # Step 2: Save session
+            with patch('rich.prompt.Prompt.ask', return_value=""):
+                result = session_commands.handle_session_command(['save', 'Test Workflow'])
+                assert "Session saved" in result
+            
+            session_id = session_commands.current_session_id
+            assert session_id is not None
+            
+            # Step 3: Continue conversation
+            user_msg2 = Message(role=Role.USER, content="Tell me about decorators")
+            cli_messages.append(user_msg2)
+            session_commands.add_message('user', 'Tell me about decorators', {})
+            
+            # Step 4: Clear conversation (simulate /clear)
+            cli_messages.clear()
+            session_commands.clear_conversation()
+            
+            assert len(cli_messages) == 0
+            assert len(session_commands.current_messages) == 0
+            
+            # Step 5: Load session back (simulate /session load)
+            session_commands._load_session(['Test Workflow'])
+            
+            # Step 6: Get restored messages for CLI
+            session_commands._messages_loaded = True
+            restored_messages = session_commands.get_loaded_messages_for_cli()
+            
+            # Step 7: Restore to CLI messages (as the integration does)
+            cli_messages.clear()
+            cli_messages.extend(restored_messages)
+            
+            # Verify conversation was restored
+            assert len(cli_messages) == 3  # 2 from saved session + 1 from before save
+            assert cli_messages[0].role == Role.USER
+            assert "Python" in cli_messages[0].content
+            assert cli_messages[1].role == Role.ASSISTANT
+            assert cli_messages[2].role == Role.USER
+            assert "decorator" in cli_messages[2].content
+            
+            # Step 8: Test that AI would have context
+            mock_provider = MockProvider()
+            cli_messages.append(Message(role=Role.USER, content="What were we discussing?"))
+            
+            response = mock_provider.chat(cli_messages, "mock-echo")
+            assert "python" in response.lower() or "decorator" in response.lower()
+            
+        finally:
+            db.close()
+    
+    @pytest.mark.asyncio
+    async def test_async_cli_integration(self, temp_db_path):
+        """Test async CLI integration with session management."""
+        # Create mock CLI components
+        from coda.cli.interactive import _handle_chat_interaction
+        
+        # This would be a more complex test simulating the actual async CLI flow
+        # For now, we verify the basic integration points work
+        
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        commands = SessionCommands(manager)
+        
+        # Test that async operations work with session commands
+        mock_cli = Mock()
+        mock_cli.session_commands = commands
+        mock_cli.current_mode = Mock()
+        mock_cli.current_mode.value = "general"
+        
+        # Simulate message addition during conversation
+        commands.add_message('user', 'Test async', {'provider': 'mock'})
+        
+        # Test async-safe operations
+        assert len(commands.current_messages) == 1
+        
+        db.close()
+
+
+@pytest.mark.integration
+class TestSessionEndToEnd:
+    """End-to-end tests for complete session functionality."""
+    
+    def test_complete_session_lifecycle(self):
+        """Test complete session lifecycle from creation to deletion."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        
+        try:
+            # Initialize
+            db = SessionDatabase(db_path)
+            manager = SessionManager(db)
+            commands = SessionCommands(manager)
+            mock_provider = MockProvider()
+            
+            # 1. Create and populate session
+            commands.add_message('user', 'Hello Python world', {})
+            commands.add_message('assistant', 'Hello! Ready to help with Python.', {})
+            
+            # 2. Save session
+            with patch('rich.prompt.Prompt.ask', return_value=""):
+                commands.handle_session_command(['save', 'Lifecycle Test'])
+            
+            session_id = commands.current_session_id
+            
+            # 3. Test search
+            results = manager.search_sessions("Python")
+            assert len(results) == 1
+            
+            # 4. Test export
+            export_data = manager.export_session(session_id, 'json')
+            assert "Python world" in export_data
+            
+            # 5. Test branching
+            messages = manager.get_messages(session_id)
+            branch = manager.create_session(
+                name="Branch Test",
+                provider="mock",
+                model="mock-echo",
+                parent_id=session_id,
+                branch_point_message_id=messages[0].id
+            )
+            
+            # 6. Test context management
+            context, truncated = manager.get_session_context(session_id, max_tokens=50)
+            assert not truncated or len(context) < 2
+            
+            # 7. Test archive
+            manager.archive_session(branch.id)
+            archived = manager.get_session(branch.id)
+            assert archived.status == 'archived'
+            
+            # 8. Test delete
+            manager.delete_session(branch.id, hard_delete=True)
+            deleted = manager.get_session(branch.id)
+            assert deleted is None
+            
+            print("✅ Complete session lifecycle test passed!")
+            
+        finally:
+            db.close()
+            db_path.unlink()

--- a/tests/providers/test_mock_provider_commands.py
+++ b/tests/providers/test_mock_provider_commands.py
@@ -1,0 +1,338 @@
+"""Tests for MockProvider with all CLI commands."""
+
+import pytest
+from unittest.mock import Mock, patch
+from coda.providers import MockProvider, Message, Role
+
+
+@pytest.mark.unit
+class TestMockProviderCommands:
+    """Test MockProvider behavior with various CLI command scenarios."""
+    
+    def test_clear_command_scenario(self):
+        """Test conversation behavior around /clear command."""
+        provider = MockProvider()
+        
+        # Build conversation
+        messages = [
+            Message(role=Role.USER, content="Tell me about Python"),
+            Message(role=Role.ASSISTANT, content="Python is a programming language..."),
+            Message(role=Role.USER, content="What about decorators?"),
+            Message(role=Role.ASSISTANT, content="Decorators are...")
+        ]
+        
+        # Ask about previous conversation
+        messages.append(Message(role=Role.USER, content="What were we discussing?"))
+        response = provider.chat(messages, "mock-echo")
+        assert "python" in response.lower() and "decorator" in response.lower()
+        
+        # Simulate /clear - start fresh conversation
+        new_messages = [Message(role=Role.USER, content="What were we discussing?")]
+        response_after_clear = provider.chat(new_messages, "mock-echo")
+        
+        # Should not remember previous conversation
+        assert "don't see any previous conversation" in response_after_clear.lower()
+    
+    def test_model_switching_scenario(self):
+        """Test conversation continuity when switching models."""
+        provider = MockProvider()
+        
+        # Start with mock-echo
+        messages = [
+            Message(role=Role.USER, content="Tell me about Python"),
+            Message(role=Role.ASSISTANT, content="Python is a programming language..."),
+        ]
+        
+        # Continue with mock-echo
+        messages.append(Message(role=Role.USER, content="What about decorators?"))
+        response_echo = provider.chat(messages, "mock-echo")
+        
+        # Switch to mock-smart (same conversation)
+        messages.append(Message(role=Role.ASSISTANT, content=response_echo))
+        messages.append(Message(role=Role.USER, content="What were we discussing?"))
+        response_smart = provider.chat(messages, "mock-smart")
+        
+        # Both models should maintain context
+        assert "python" in response_smart.lower() and "decorator" in response_smart.lower()
+    
+    def test_mode_command_scenarios(self):
+        """Test conversations with mode switching."""
+        provider = MockProvider()
+        
+        # Simulate mode switches in conversation
+        mode_prompts = {
+            "general": "You are a helpful AI assistant",
+            "code": "You are a code writing assistant",
+            "debug": "You are a debugging assistant",
+            "explain": "You are a code explanation assistant",
+            "review": "You are a code review assistant",
+            "refactor": "You are a refactoring assistant",
+            "plan": "You are an architecture planning assistant"
+        }
+        
+        for mode, prompt in mode_prompts.items():
+            messages = [
+                Message(role=Role.SYSTEM, content=prompt),
+                Message(role=Role.USER, content=f"I need help with Python in {mode} mode")
+            ]
+            
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should handle all modes
+            assert response
+            assert len(response) > 10
+            if "python" in messages[1].content.lower():
+                assert "python" in response.lower()
+    
+    def test_session_command_scenarios(self):
+        """Test conversation patterns for session management."""
+        provider = MockProvider()
+        
+        # Build a conversation worth saving
+        messages = [
+            Message(role=Role.USER, content="Let's discuss Python web frameworks"),
+            Message(role=Role.ASSISTANT, content="Python has many web frameworks..."),
+            Message(role=Role.USER, content="Tell me about Flask"),
+            Message(role=Role.ASSISTANT, content="Flask is a micro framework..."),
+            Message(role=Role.USER, content="What about Django?"),
+            Message(role=Role.ASSISTANT, content="Django is a full-featured framework...")
+        ]
+        
+        # User might ask to summarize before saving
+        messages.append(Message(role=Role.USER, content="What were we discussing?"))
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should be able to summarize the conversation
+        assert response
+        assert "python" in response.lower()  # Should recognize Python was discussed
+        
+        # Simulate loading a session - asking about context
+        loaded_messages = messages.copy()
+        loaded_messages.append(Message(role=Role.USER, content="What were we talking about?"))
+        response_loaded = provider.chat(loaded_messages, "mock-echo")
+        
+        # Should remember the context
+        assert any(word in response_loaded.lower() for word in ["python", "flask", "django", "framework"])
+    
+    def test_export_command_scenarios(self):
+        """Test conversations that might be exported."""
+        provider = MockProvider()
+        
+        # Create a conversation with various content types
+        messages = [
+            Message(role=Role.USER, content="Show me a Python decorator"),
+            Message(role=Role.ASSISTANT, content="Here's a decorator example..."),
+            Message(role=Role.USER, content="Can you explain how it works?"),
+            Message(role=Role.ASSISTANT, content="The decorator modifies..."),
+            Message(role=Role.USER, content="What else can decorators do?")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should handle export-worthy conversations
+        assert response
+        assert "decorator" in response.lower() or "python" in response.lower()
+    
+    def test_help_command_context(self):
+        """Test asking for help in various contexts."""
+        provider = MockProvider()
+        
+        # User asks for help mid-conversation
+        messages = [
+            Message(role=Role.USER, content="I'm learning Python"),
+            Message(role=Role.ASSISTANT, content="Great! Python is..."),
+            Message(role=Role.USER, content="help")  # Could be asking for help
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should provide some help response
+        assert "help" in response.lower()
+    
+    def test_provider_command_scenario(self):
+        """Test provider-related conversations."""
+        provider = MockProvider()
+        
+        # User might ask about providers
+        messages = [
+            Message(role=Role.USER, content="What AI provider are you using?"),
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should handle provider questions
+        assert response
+        assert len(response) > 10
+    
+    def test_command_error_scenarios(self):
+        """Test error scenarios with commands."""
+        provider = MockProvider()
+        
+        # Misspelled or invalid command references
+        error_scenarios = [
+            "I tried /cleear but it didn't work",
+            "The /modle command isn't working",
+            "How do I use /sesion save?",
+            "Is there a /delete command?"
+        ]
+        
+        for scenario in error_scenarios:
+            messages = [Message(role=Role.USER, content=scenario)]
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should still provide a response
+            assert response
+            assert len(response) > 5
+    
+    def test_interactive_only_commands(self):
+        """Test scenarios with interactive-only commands."""
+        provider = MockProvider()
+        
+        # These commands are only in interactive mode
+        interactive_commands = [
+            "How do I save this session?",
+            "Can I export this conversation?",
+            "How do I search my sessions?",
+            "Tell me about the tools command"
+        ]
+        
+        for command_question in interactive_commands:
+            messages = [Message(role=Role.USER, content=command_question)]
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should handle questions about commands
+            assert response
+            assert len(response) > 10
+    
+    def test_command_combination_scenarios(self):
+        """Test complex scenarios with multiple commands."""
+        provider = MockProvider()
+        
+        # Scenario: User switches mode, then model, then asks question
+        messages = [
+            Message(role=Role.SYSTEM, content="You are in code mode"),
+            Message(role=Role.USER, content="I just switched to code mode"),
+            Message(role=Role.ASSISTANT, content="Great! I'm ready to help with code."),
+            Message(role=Role.USER, content="And I'm using the smart model now"),
+            Message(role=Role.ASSISTANT, content="Excellent choice!"),
+            Message(role=Role.USER, content="Show me a Python class example")
+        ]
+        
+        response = provider.chat(messages, "mock-smart")
+        
+        # Should handle the Python request
+        assert "python" in response.lower() or "class" in response.lower()
+    
+    def test_coming_soon_commands(self):
+        """Test conversations about coming soon features."""
+        provider = MockProvider()
+        
+        coming_soon = [
+            "When will the tools command be available?",
+            "I want to change the theme",
+            "Tell me about MCP tools"
+        ]
+        
+        for question in coming_soon:
+            messages = [Message(role=Role.USER, content=question)]
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should handle gracefully
+            assert response
+            assert len(response) > 5
+
+
+@pytest.mark.unit
+class TestMockProviderCommandIntegration:
+    """Test how MockProvider integrates with command workflows."""
+    
+    def test_full_session_workflow(self):
+        """Test a complete session workflow with MockProvider."""
+        provider = MockProvider()
+        
+        # 1. Start conversation
+        messages = [
+            Message(role=Role.USER, content="I need help with Python async programming")
+        ]
+        response1 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        
+        # 2. Ask specific question
+        messages.append(Message(role=Role.USER, content="How do I use async/await?"))
+        response2 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response2))
+        
+        # 3. User wants to save session
+        messages.append(Message(role=Role.USER, content="This is helpful, I should save this"))
+        response3 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response3))
+        
+        # 4. Continue conversation
+        messages.append(Message(role=Role.USER, content="What about asyncio?"))
+        response4 = provider.chat(messages, "mock-echo")
+        
+        # Should maintain context throughout
+        assert response4
+        
+        # 5. Check context is maintained
+        messages.append(Message(role=Role.ASSISTANT, content=response4))
+        messages.append(Message(role=Role.USER, content="What have we covered so far?"))
+        summary = provider.chat(messages, "mock-echo")
+        
+        # Should remember the async/Python discussion
+        assert "python" in summary.lower() or "async" in summary.lower()
+    
+    def test_mode_switching_workflow(self):
+        """Test workflow with multiple mode switches."""
+        provider = MockProvider()
+        
+        workflows = [
+            # General -> Code
+            {
+                "messages": [
+                    (Role.SYSTEM, "You are in general mode"),
+                    (Role.USER, "Hi, I want to learn programming"),
+                    (Role.ASSISTANT, "Hello! I can help..."),
+                    (Role.SYSTEM, "You are in code mode"),
+                    (Role.USER, "Show me a Python example")
+                ],
+                "final_check": "python"
+            },
+            # Code -> Debug
+            {
+                "messages": [
+                    (Role.SYSTEM, "You are in code mode"),
+                    (Role.USER, "Here's my Python function"),
+                    (Role.ASSISTANT, "I see your function..."),
+                    (Role.SYSTEM, "You are in debug mode"),
+                    (Role.USER, "Why isn't it working?")
+                ],
+                "final_check": "python"
+            },
+            # Debug -> Explain
+            {
+                "messages": [
+                    (Role.SYSTEM, "You are in debug mode"),
+                    (Role.USER, "Found the bug in my Python code"),
+                    (Role.ASSISTANT, "Good job finding it..."),
+                    (Role.SYSTEM, "You are in explain mode"),
+                    (Role.USER, "Can you explain why that happened?")
+                ],
+                "final_check": "python"
+            }
+        ]
+        
+        for workflow in workflows:
+            messages = []
+            for role, content in workflow["messages"][:-1]:
+                messages.append(Message(role=role, content=content))
+            
+            # Add final user message
+            final_role, final_content = workflow["messages"][-1]
+            messages.append(Message(role=final_role, content=final_content))
+            
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should maintain context through mode switches
+            if workflow["final_check"] in messages[-1].content.lower():
+                assert workflow["final_check"] in response.lower() or len(response) > 10

--- a/tests/providers/test_mock_provider_conversations.py
+++ b/tests/providers/test_mock_provider_conversations.py
@@ -1,0 +1,209 @@
+"""Comprehensive tests for MockProvider conversation functionality."""
+
+import pytest
+from coda.providers import MockProvider, Message, Role
+
+
+@pytest.mark.unit
+class TestMockProviderConversations:
+    """Test MockProvider's conversation handling and context awareness."""
+    
+    def test_single_turn_conversation(self):
+        """Test basic single-turn conversations."""
+        provider = MockProvider()
+        
+        # Test simple greeting
+        messages = [Message(role=Role.USER, content="Hello")]
+        response = provider.chat(messages, "mock-echo")
+        assert "hello" in response.lower()
+        assert len(response) > 5  # Should be more than just "hello"
+        
+        # Test question
+        messages = [Message(role=Role.USER, content="What is 2+2?")]
+        response = provider.chat(messages, "mock-echo")
+        assert response  # Should get a response
+        
+    def test_multi_turn_conversation_basic(self):
+        """Test basic multi-turn conversation flow."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # First turn
+        messages.append(Message(role=Role.USER, content="My name is Alice"))
+        response1 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        
+        # Second turn - should remember name
+        messages.append(Message(role=Role.USER, content="What's my name?"))
+        response2 = provider.chat(messages, "mock-echo")
+        
+        assert "alice" in response2.lower(), "MockProvider should remember the name from context"
+        
+    def test_python_context_awareness(self):
+        """Test MockProvider's Python-specific context awareness."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # Ask about Python
+        messages.append(Message(role=Role.USER, content="What is Python?"))
+        response1 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        
+        assert "python" in response1.lower()
+        assert any(word in response1.lower() for word in ["programming", "language", "code"])
+        
+        # Follow-up about decorators
+        messages.append(Message(role=Role.USER, content="Tell me about decorators"))
+        response2 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response2))
+        
+        assert "decorator" in response2.lower()
+        assert "python" in response2.lower(), "Should maintain Python context"
+        
+        # Ask for example
+        messages.append(Message(role=Role.USER, content="Can you show me an example?"))
+        response3 = provider.chat(messages, "mock-echo")
+        
+        assert "@" in response3 or "decorator" in response3.lower(), "Should provide decorator example"
+        
+    def test_conversation_context_switching(self):
+        """Test switching between different conversation topics."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # Start with Python topic
+        messages.append(Message(role=Role.USER, content="Tell me about Python"))
+        response1 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        
+        assert "python" in response1.lower()
+        
+        # Switch to JavaScript topic
+        messages.append(Message(role=Role.USER, content="Now tell me about JavaScript"))
+        response2 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response2))
+        
+        # Should mention JavaScript
+        assert "javascript" in response2.lower()
+        
+        # Ask about what we were discussing
+        messages.append(Message(role=Role.USER, content="What were we discussing?"))
+        response3 = provider.chat(messages, "mock-echo")
+        
+        # Should mention both topics
+        assert "python" in response3.lower() and "javascript" in response3.lower()
+        
+    def test_system_message_handling(self):
+        """Test handling of system messages in conversations."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.SYSTEM, content="You are a helpful Python tutor."),
+            Message(role=Role.USER, content="Tell me about Python")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should respond about Python
+        assert "python" in response.lower()
+        
+    def test_long_conversation_context(self):
+        """Test maintaining context over longer conversations."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # Build up conversation about Python topics
+        topics = [
+            "Tell me about Python",
+            "What about Python decorators?",
+            "And Python functions?",
+            "What were we discussing?"
+        ]
+        
+        for i, user_msg in enumerate(topics):
+            messages.append(Message(role=Role.USER, content=user_msg))
+            response = provider.chat(messages, "mock-echo")
+            messages.append(Message(role=Role.ASSISTANT, content=response))
+            
+            if i < 3:  # First three should mention Python or decorators
+                assert "python" in response.lower() or "decorator" in response.lower()
+            else:  # Last one should mention what we were discussing
+                assert "python" in response.lower()
+        
+    def test_conversation_memory_limits(self):
+        """Test how MockProvider handles very long conversations."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # Add many messages
+        for i in range(10):
+            messages.append(Message(role=Role.USER, content=f"Message {i}"))
+            response = provider.chat(messages, "mock-echo")
+            messages.append(Message(role=Role.ASSISTANT, content=response))
+        
+        # Should still respond with echo pattern
+        messages.append(Message(role=Role.USER, content="Final message"))
+        final_response = provider.chat(messages, "mock-echo")
+        
+        assert "final message" in final_response.lower()  # Should echo the message
+        assert len(final_response) > 10  # Should be a meaningful response
+        
+    def test_question_answering_patterns(self):
+        """Test different question-answering patterns."""
+        provider = MockProvider()
+        
+        # Test questions the MockProvider specifically handles
+        qa_pairs = [
+            ("What is Python?", "python"),
+            ("Tell me about decorators", "decorator"),
+            ("What is JavaScript?", "javascript"),
+        ]
+        
+        for question, expected_keyword in qa_pairs:
+            messages = [Message(role=Role.USER, content=question)]
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should mention the expected keyword
+            assert expected_keyword in response.lower(), \
+                f"Response to '{question}' should mention '{expected_keyword}'"
+            
+    def test_code_generation_requests(self):
+        """Test handling of code generation requests."""
+        provider = MockProvider()
+        
+        # Test decorator example request
+        messages = [Message(role=Role.USER, content="Show me a decorator example")]
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should mention decorators or @ symbol
+        assert "decorator" in response.lower() or "@" in response
+            
+    def test_conversation_branching_scenarios(self):
+        """Test different conversation branches from same starting point."""
+        provider = MockProvider()
+        
+        # Base conversation about Python
+        base_messages = [
+            Message(role=Role.USER, content="Tell me about Python"),
+            Message(role=Role.ASSISTANT, content="Python is a high-level programming language...")
+        ]
+        
+        # Branch 1: Ask about decorators
+        branch1 = base_messages.copy()
+        branch1.append(Message(role=Role.USER, content="Tell me about decorators"))
+        response1 = provider.chat(branch1, "mock-echo")
+        assert "decorator" in response1.lower()
+        
+        # Branch 2: Ask about JavaScript
+        branch2 = base_messages.copy()
+        branch2.append(Message(role=Role.USER, content="Tell me about JavaScript"))
+        response2 = provider.chat(branch2, "mock-echo")
+        assert "javascript" in response2.lower()
+        
+        # Responses should be different
+        assert response1 != response2, "Different branches should yield different responses"

--- a/tests/providers/test_mock_provider_edge_cases.py
+++ b/tests/providers/test_mock_provider_edge_cases.py
@@ -1,0 +1,233 @@
+"""Edge case tests for MockProvider conversation handling."""
+
+import pytest
+from coda.providers import MockProvider, Message, Role
+
+
+@pytest.mark.unit
+class TestMockProviderEdgeCases:
+    """Test edge cases and special scenarios for MockProvider conversations."""
+    
+    def test_empty_conversation(self):
+        """Test handling of empty message list."""
+        provider = MockProvider()
+        
+        # Empty messages should still work
+        response = provider.chat([], "mock-echo")
+        assert response  # Should return something
+        assert isinstance(response, str)
+        
+    def test_single_system_message_only(self):
+        """Test conversation with only system message."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.SYSTEM, content="You are a code reviewer.")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert response  # Should handle gracefully
+        
+    def test_malformed_conversation_history(self):
+        """Test handling of unusual conversation patterns."""
+        provider = MockProvider()
+        
+        # Multiple user messages in a row
+        messages = [
+            Message(role=Role.USER, content="First question"),
+            Message(role=Role.USER, content="Second question"),
+            Message(role=Role.USER, content="Third question")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert response  # Should handle multiple questions
+        
+        # Multiple assistant messages
+        messages2 = [
+            Message(role=Role.ASSISTANT, content="Previous response 1"),
+            Message(role=Role.ASSISTANT, content="Previous response 2"),
+            Message(role=Role.USER, content="New question")
+        ]
+        
+        response2 = provider.chat(messages2, "mock-echo")
+        assert response2  # Should handle gracefully
+        
+    def test_very_long_messages(self):
+        """Test handling of very long messages."""
+        provider = MockProvider()
+        
+        # Very long user message
+        long_content = "Python " * 1000  # Very long message
+        messages = [Message(role=Role.USER, content=long_content)]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert response
+        assert len(response) < len(long_content)  # Should not echo entire long message
+        
+    def test_special_characters_and_formatting(self):
+        """Test handling of special characters and formatting."""
+        provider = MockProvider()
+        
+        special_inputs = [
+            "Can you help with this code?\n```python\ndef foo():\n    pass\n```",
+            "What about unicode? 你好 🎉 café",
+            "Markdown **bold** and *italic* and `code`",
+            "Special chars: <>&\"'",
+            "Math expressions: x^2 + y^2 = z^2"
+        ]
+        
+        for input_text in special_inputs:
+            messages = [Message(role=Role.USER, content=input_text)]
+            response = provider.chat(messages, "mock-echo")
+            assert response  # Should handle all special inputs
+            
+    def test_conversation_with_names(self):
+        """Test handling of messages with name attributes."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.USER, content="Hello from user1", name="user1"),
+            Message(role=Role.ASSISTANT, content="Hello user1!"),
+            Message(role=Role.USER, content="Hello from user2", name="user2"),
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert response  # Should handle named messages
+        
+    def test_rapid_context_switches(self):
+        """Test handling of rapid context switches."""
+        provider = MockProvider()
+        
+        messages = []
+        # Use topics that MockProvider specifically handles
+        topics = [("Python", "python"), ("JavaScript", "javascript"), ("decorators", "decorator")]
+        
+        for topic, expected in topics:
+            messages.append(Message(role=Role.USER, content=f"Tell me about {topic}"))
+            response = provider.chat(messages, "mock-echo")
+            messages.append(Message(role=Role.ASSISTANT, content=response))
+            
+            # Should mention the expected keyword
+            assert expected in response.lower()
+            
+    def test_error_recovery_scenarios(self):
+        """Test conversation recovery after confusing inputs."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.USER, content="ajsdkfj aslkdfj alskdjf"),  # Gibberish
+            Message(role=Role.ASSISTANT, content="I'm not sure I understand..."),
+            Message(role=Role.USER, content="Sorry, I meant to ask about Python lists")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should recover and talk about Python lists
+        assert any(word in response.lower() for word in ["python", "list"])
+        
+    def test_conversation_state_isolation(self):
+        """Test that different conversation instances don't interfere."""
+        provider = MockProvider()
+        
+        # First conversation about Python
+        conv1 = [
+            Message(role=Role.USER, content="Let's talk about Python"),
+            Message(role=Role.ASSISTANT, content="Python is a great language..."),
+            Message(role=Role.USER, content="What makes it special?")
+        ]
+        response1 = provider.chat(conv1, "mock-echo")
+        
+        # Second conversation about Java (completely separate)
+        conv2 = [
+            Message(role=Role.USER, content="Tell me about Java"),
+            Message(role=Role.ASSISTANT, content="Java is an object-oriented language..."),
+            Message(role=Role.USER, content="What makes it special?")
+        ]
+        response2 = provider.chat(conv2, "mock-echo")
+        
+        # Responses should be contextually different
+        assert "python" in response1.lower()
+        assert "java" in response2.lower()
+        
+    def test_recursive_question_patterns(self):
+        """Test handling of recursive or self-referential questions."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.USER, content="What's your previous response?"),
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert response  # Should handle gracefully without previous context
+        
+        # Add context and ask again
+        messages.append(Message(role=Role.ASSISTANT, content=response))
+        messages.append(Message(role=Role.USER, content="What did you just say?"))
+        
+        response2 = provider.chat(messages, "mock-echo")
+        assert response2  # Should reference or acknowledge previous response
+        
+    def test_mixed_language_conversation(self):
+        """Test handling of mixed language inputs."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.USER, content="Hello, comment allez-vous?"),
+            Message(role=Role.ASSISTANT, content="Hello! I'm doing well."),
+            Message(role=Role.USER, content="Can you explain Python's list comprehensions?")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert response  # Should handle language mix gracefully
+        assert any(word in response.lower() for word in ["list", "comprehension", "python"])
+        
+    def test_conversation_with_code_context(self):
+        """Test maintaining context when discussing code."""
+        provider = MockProvider()
+        
+        messages = [
+            Message(role=Role.USER, content="Here's my code: def add(a, b): return a + b"),
+            Message(role=Role.ASSISTANT, content="That's a simple addition function..."),
+            Message(role=Role.USER, content="How can I make it handle strings too?")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should reference the function context
+        assert any(word in response.lower() for word in ["add", "string", "type", "check"])
+        
+    def test_number_and_data_questions(self):
+        """Test handling of numerical and data-related questions."""
+        provider = MockProvider()
+        
+        # MockProvider will echo these questions since they don't match specific patterns
+        numerical_questions = [
+            "What's 123 + 456?",
+            "How many bytes in a kilobyte?",
+            "What's the factorial of 5?"
+        ]
+        
+        for question in numerical_questions:
+            messages = [Message(role=Role.USER, content=question)]
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should echo back the question in some form
+            assert "You said:" in response or len(response) > 10
+            
+    def test_conversation_persistence_check(self):
+        """Test that conversations maintain their context properly."""
+        provider = MockProvider()
+        
+        # Build conversation about a specific project
+        messages = [
+            Message(role=Role.USER, content="I'm building a TODO app"),
+            Message(role=Role.ASSISTANT, content="A TODO app is a great project..."),
+            Message(role=Role.USER, content="I want to use SQLite for storage"),
+            Message(role=Role.ASSISTANT, content="SQLite is perfect for TODO apps..."),
+            Message(role=Role.USER, content="What columns should my tasks table have?")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        
+        # Should remember we're talking about TODO app with SQLite
+        assert any(word in response.lower() for word in ["todo", "task", "sqlite", "column", "table"])

--- a/tests/providers/test_mock_provider_modes.py
+++ b/tests/providers/test_mock_provider_modes.py
@@ -1,0 +1,340 @@
+"""Tests for MockProvider with different modes and models."""
+
+import pytest
+from coda.providers import MockProvider, Message, Role
+
+
+@pytest.mark.unit
+class TestMockProviderModes:
+    """Test MockProvider behavior across all developer modes."""
+    
+    # All available developer modes
+    DEVELOPER_MODES = [
+        "general",
+        "code", 
+        "debug",
+        "explain",
+        "review",
+        "refactor",
+        "plan"
+    ]
+    
+    def test_all_modes_with_system_prompts(self):
+        """Test that MockProvider works with all modes' system prompts."""
+        provider = MockProvider()
+        
+        for mode in self.DEVELOPER_MODES:
+            # Each mode would have its own system prompt in real usage
+            system_prompt = f"You are in {mode} mode"
+            messages = [
+                Message(role=Role.SYSTEM, content=system_prompt),
+                Message(role=Role.USER, content="Tell me about Python")
+            ]
+            
+            response = provider.chat(messages, "mock-echo")
+            
+            # MockProvider should respond about Python regardless of mode
+            assert "python" in response.lower(), f"Failed for mode: {mode}"
+            assert len(response) > 10, f"Response too short for mode: {mode}"
+    
+    def test_mode_switching_scenarios(self):
+        """Test conversation behavior when switching between modes."""
+        provider = MockProvider()
+        
+        # Start in code mode
+        messages = [
+            Message(role=Role.SYSTEM, content="You are in code mode"),
+            Message(role=Role.USER, content="Write a Python function")
+        ]
+        response1 = provider.chat(messages, "mock-echo")
+        
+        # Switch to debug mode (simulated by changing system prompt)
+        messages[0] = Message(role=Role.SYSTEM, content="You are in debug mode")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        messages.append(Message(role=Role.USER, content="Debug this Python code"))
+        response2 = provider.chat(messages, "mock-echo")
+        
+        # Both should mention Python
+        assert "python" in response1.lower()
+        assert "python" in response2.lower()
+    
+    def test_mode_specific_questions(self):
+        """Test mode-appropriate questions across all modes."""
+        provider = MockProvider()
+        
+        mode_questions = {
+            "general": "How are you today?",
+            "code": "Write a Python decorator",
+            "debug": "Why is my Python code failing?",
+            "explain": "Explain Python decorators",
+            "review": "Review this Python code for security",
+            "refactor": "Refactor this Python function",
+            "plan": "Plan a Python web application"
+        }
+        
+        for mode, question in mode_questions.items():
+            messages = [
+                Message(role=Role.SYSTEM, content=f"You are in {mode} mode"),
+                Message(role=Role.USER, content=question)
+            ]
+            
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should get a response for each mode
+            assert response, f"No response for mode: {mode}"
+            assert len(response) > 5, f"Response too short for mode: {mode}"
+            
+            # Python-related questions should trigger Python responses
+            if "python" in question.lower():
+                assert "python" in response.lower() or "decorator" in response.lower(), \
+                    f"Python not mentioned for mode: {mode}"
+    
+    def test_conversation_continuity_across_modes(self):
+        """Test that conversation context is maintained when mode changes."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # Start conversation in general mode about Python
+        messages.append(Message(role=Role.SYSTEM, content="You are in general mode"))
+        messages.append(Message(role=Role.USER, content="I'm learning Python"))
+        response1 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        
+        # Continue in code mode
+        messages[0] = Message(role=Role.SYSTEM, content="You are in code mode")
+        messages.append(Message(role=Role.USER, content="Show me a decorator example"))
+        response2 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response2))
+        
+        # Switch to explain mode and ask about previous topic
+        messages[0] = Message(role=Role.SYSTEM, content="You are in explain mode")
+        messages.append(Message(role=Role.USER, content="What were we discussing?"))
+        response3 = provider.chat(messages, "mock-echo")
+        
+        # Should remember Python and decorators were discussed
+        assert "python" in response3.lower(), "Should remember Python discussion"
+        assert "decorator" in response3.lower(), "Should remember decorator discussion"
+    
+    def test_edge_cases_with_modes(self):
+        """Test edge cases with different modes."""
+        provider = MockProvider()
+        
+        # Empty user message in different modes
+        for mode in self.DEVELOPER_MODES:
+            messages = [
+                Message(role=Role.SYSTEM, content=f"You are in {mode} mode"),
+                Message(role=Role.USER, content="")
+            ]
+            
+            response = provider.chat(messages, "mock-echo")
+            assert response  # Should handle empty messages gracefully
+        
+        # Very long system prompts
+        long_prompt = "You are in code mode. " * 100
+        messages = [
+            Message(role=Role.SYSTEM, content=long_prompt),
+            Message(role=Role.USER, content="Hello")
+        ]
+        
+        response = provider.chat(messages, "mock-echo")
+        assert "hello" in response.lower()
+
+
+@pytest.mark.unit
+class TestMockProviderModels:
+    """Test both mock-echo and mock-smart models."""
+    
+    def test_both_models_basic_functionality(self):
+        """Test that both models work for basic conversations."""
+        provider = MockProvider()
+        
+        models = ["mock-echo", "mock-smart"]
+        
+        for model in models:
+            messages = [Message(role=Role.USER, content="Hello")]
+            response = provider.chat(messages, model)
+            
+            assert "hello" in response.lower(), f"Failed for model: {model}"
+            assert len(response) > 5, f"Response too short for model: {model}"
+    
+    def test_both_models_python_awareness(self):
+        """Test that both models handle Python topics."""
+        provider = MockProvider()
+        
+        models = ["mock-echo", "mock-smart"]
+        
+        for model in models:
+            messages = [
+                Message(role=Role.USER, content="What is Python?"),
+                Message(role=Role.ASSISTANT, content="Python is a programming language..."),
+                Message(role=Role.USER, content="Tell me about decorators")
+            ]
+            
+            response = provider.chat(messages, model)
+            
+            assert "decorator" in response.lower(), f"Failed for model: {model}"
+            assert "python" in response.lower(), f"Failed for model: {model}"
+    
+    def test_both_models_conversation_memory(self):
+        """Test that both models maintain conversation context."""
+        provider = MockProvider()
+        
+        models = ["mock-echo", "mock-smart"]
+        
+        for model in models:
+            messages = [
+                Message(role=Role.USER, content="My name is Alice"),
+                Message(role=Role.ASSISTANT, content="Nice to meet you, Alice!"),
+                Message(role=Role.USER, content="What's my name?")
+            ]
+            
+            response = provider.chat(messages, model)
+            
+            assert "alice" in response.lower(), f"Failed to remember name for model: {model}"
+    
+    def test_model_metadata_differences(self):
+        """Test that models have different metadata but same behavior."""
+        provider = MockProvider()
+        
+        # Get model info
+        echo_info = provider.get_model_info("mock-echo")
+        smart_info = provider.get_model_info("mock-smart")
+        
+        # Check metadata differences
+        assert echo_info["context_window"] == 4096
+        assert smart_info["context_window"] == 8192
+        assert echo_info["name"] == "Mock Echo Model"
+        assert smart_info["name"] == "Mock Smart Model"
+        
+        # But behavior should be identical
+        messages = [Message(role=Role.USER, content="Tell me about Python")]
+        
+        echo_response = provider.chat(messages, "mock-echo")
+        smart_response = provider.chat(messages, "mock-smart")
+        
+        # Both should mention Python
+        assert "python" in echo_response.lower()
+        assert "python" in smart_response.lower()
+    
+    def test_streaming_both_models(self):
+        """Test streaming functionality for both models."""
+        provider = MockProvider()
+        
+        models = ["mock-echo", "mock-smart"]
+        
+        for model in models:
+            messages = [Message(role=Role.USER, content="Hello world")]
+            
+            # Collect streamed chunks
+            chunks = []
+            for chunk in provider.chat_stream(messages, model):
+                chunks.append(chunk.content)
+            
+            # Reconstruct full response
+            full_response = "".join(chunks)
+            
+            assert "hello" in full_response.lower(), f"Streaming failed for model: {model}"
+            assert len(chunks) > 1, f"Should stream multiple chunks for model: {model}"
+    
+    def test_error_handling_both_models(self):
+        """Test error handling for both models."""
+        provider = MockProvider()
+        
+        # MockProvider accepts any model name without validation
+        response = provider.chat([Message(role=Role.USER, content="Test")], "invalid-model")
+        assert response  # Should still work
+        
+        # Test model info for invalid model
+        with pytest.raises(ValueError):
+            provider.get_model_info("invalid-model")
+        
+        # Both valid models should work
+        for model in ["mock-echo", "mock-smart"]:
+            response = provider.chat([Message(role=Role.USER, content="Test")], model)
+            assert response  # Should not raise error
+
+
+@pytest.mark.unit 
+class TestMockProviderModesAndModels:
+    """Test combinations of modes and models."""
+    
+    def test_all_mode_model_combinations(self):
+        """Test all combinations of modes and models."""
+        provider = MockProvider()
+        
+        modes = ["general", "code", "debug", "explain", "review", "refactor", "plan"]
+        models = ["mock-echo", "mock-smart"]
+        
+        for mode in modes:
+            for model in models:
+                messages = [
+                    Message(role=Role.SYSTEM, content=f"You are in {mode} mode"),
+                    Message(role=Role.USER, content="Tell me about Python")
+                ]
+                
+                response = provider.chat(messages, model)
+                
+                assert response, f"No response for mode={mode}, model={model}"
+                assert "python" in response.lower(), \
+                    f"Python not mentioned for mode={mode}, model={model}"
+    
+    def test_mode_model_conversation_flow(self):
+        """Test a complete conversation flow with mode and model changes."""
+        provider = MockProvider()
+        
+        messages = []
+        
+        # Start with general mode and echo model
+        messages.append(Message(role=Role.SYSTEM, content="You are in general mode"))
+        messages.append(Message(role=Role.USER, content="I want to learn programming"))
+        response1 = provider.chat(messages, "mock-echo")
+        messages.append(Message(role=Role.ASSISTANT, content=response1))
+        
+        # Switch to code mode with smart model
+        messages[0] = Message(role=Role.SYSTEM, content="You are in code mode")
+        messages.append(Message(role=Role.USER, content="Show me Python basics"))
+        response2 = provider.chat(messages, "mock-smart")
+        messages.append(Message(role=Role.ASSISTANT, content=response2))
+        
+        # Switch to debug mode with echo model
+        messages[0] = Message(role=Role.SYSTEM, content="You are in debug mode")
+        messages.append(Message(role=Role.USER, content="What were we discussing?"))
+        response3 = provider.chat(messages, "mock-echo")
+        
+        # Should maintain context regardless of mode/model switches
+        assert any(word in response3.lower() for word in ["python", "programming"])
+    
+    def test_async_methods_with_modes_and_models(self):
+        """Test async methods work with all modes and models."""
+        import asyncio
+        
+        async def test_async():
+            provider = MockProvider()
+            
+            # Test a few combinations
+            combinations = [
+                ("general", "mock-echo"),
+                ("code", "mock-smart"),
+                ("debug", "mock-echo")
+            ]
+            
+            for mode, model in combinations:
+                messages = [
+                    Message(role=Role.SYSTEM, content=f"You are in {mode} mode"),
+                    Message(role=Role.USER, content="Test async")
+                ]
+                
+                # Test async chat
+                response = await provider.achat(messages, model)
+                assert response, f"Async chat failed for mode={mode}, model={model}"
+                
+                # Test async streaming
+                chunks = []
+                async for chunk in provider.achat_stream(messages, model):
+                    chunks.append(chunk.content)
+                
+                assert len(chunks) > 0, f"Async streaming failed for mode={mode}, model={model}"
+        
+        # Run async test
+        asyncio.run(test_async())

--- a/tests/session/__init__.py
+++ b/tests/session/__init__.py
@@ -1,0 +1,1 @@
+"""Session management tests."""

--- a/tests/session/test_commands.py
+++ b/tests/session/test_commands.py
@@ -1,0 +1,267 @@
+"""Tests for session command functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+import pytest
+
+from coda.session import SessionCommands, SessionDatabase, SessionManager
+
+
+class TestSessionCommands:
+    """Test session command handling."""
+    
+    @pytest.fixture
+    def session_commands(self):
+        """Create session commands with temporary database."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        
+        db = SessionDatabase(db_path)
+        manager = SessionManager(db)
+        commands = SessionCommands(manager)
+        yield commands
+        
+        # Cleanup
+        db.close()
+        db_path.unlink()
+    
+    def test_help_command(self, session_commands, capsys):
+        """Test session help display."""
+        result = session_commands.handle_session_command([])
+        
+        # Should return None and print help
+        assert result is None
+        
+        # Check console output (mock console captures this)
+        # In real implementation, this would be captured by Rich console
+    
+    def test_save_command_no_messages(self, session_commands):
+        """Test saving with no messages."""
+        result = session_commands.handle_session_command(['save', 'Test Session'])
+        assert result == "No messages to save."
+    
+    def test_save_and_load_session(self, session_commands):
+        """Test saving and loading a session."""
+        # Add some messages
+        session_commands.add_message('user', 'Hello', {'provider': 'test', 'model': 'test-model'})
+        session_commands.add_message('assistant', 'Hi there!', {'provider': 'test', 'model': 'test-model'})
+        
+        # Save session
+        result = session_commands.handle_session_command(['save', 'My Test Session'])
+        assert "Session saved: My Test Session" in result
+        assert session_commands.current_session_id is not None
+        
+        # Clear and verify
+        session_commands.clear_conversation()
+        assert len(session_commands.current_messages) == 0
+        
+        # Load session by name
+        result = session_commands.handle_session_command(['load', 'My Test Session'])
+        assert result is None  # Load prints directly to console
+        assert len(session_commands.current_messages) == 2
+        assert session_commands.current_messages[0]['content'] == 'Hello'
+    
+    def test_list_sessions(self, session_commands):
+        """Test listing sessions."""
+        # Create some sessions
+        session_commands.add_message('user', 'Test 1', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Session 1'])
+        
+        session_commands.clear_conversation()
+        session_commands.add_message('user', 'Test 2', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Session 2'])
+        
+        # List sessions
+        result = session_commands.handle_session_command(['list'])
+        assert result is None  # List displays table directly
+    
+    def test_branch_session(self, session_commands):
+        """Test branching from current session."""
+        # Create and save initial session
+        session_commands.add_message('user', 'Original message', {'provider': 'test', 'model': 'test'})
+        session_commands.add_message('assistant', 'Original response', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Original Session'])
+        
+        # Branch from current
+        result = session_commands.handle_session_command(['branch', 'Branched Session'])
+        assert "Created branch: Branched Session" in result
+        
+        # Verify we're now on the branch
+        parent_id = session_commands.current_session_id
+        assert parent_id is not None
+    
+    def test_delete_session(self, session_commands):
+        """Test deleting a session."""
+        # Create a session
+        session_commands.add_message('user', 'Delete me', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'To Delete'])
+        session_id = session_commands.current_session_id
+        
+        # Mock confirmation
+        with patch('rich.prompt.Confirm.ask', return_value=True):
+            result = session_commands.handle_session_command(['delete', 'To Delete'])
+            assert "Session deleted: To Delete" in result
+            assert session_commands.current_session_id is None
+    
+    def test_delete_cancelled(self, session_commands):
+        """Test cancelling session deletion."""
+        # Create a session
+        session_commands.add_message('user', 'Keep me', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'To Keep'])
+        
+        # Mock confirmation denial
+        with patch('rich.prompt.Confirm.ask', return_value=False):
+            result = session_commands.handle_session_command(['delete', 'To Keep'])
+            assert result == "Deletion cancelled."
+    
+    def test_session_info(self, session_commands):
+        """Test displaying session information."""
+        # Create a session with some data
+        session_commands.add_message('user', 'Info test', {
+            'provider': 'test_provider',
+            'model': 'test_model',
+            'mode': 'general'
+        })
+        session_commands.handle_session_command(['save', 'Info Session'])
+        
+        # Get info for current session
+        result = session_commands.handle_session_command(['info'])
+        assert result is None  # Info displays panel directly
+    
+    def test_search_sessions(self, session_commands):
+        """Test searching across sessions."""
+        # Create sessions with searchable content
+        session_commands.add_message('user', 'Python programming question', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Python Session'])
+        
+        session_commands.clear_conversation()
+        session_commands.add_message('user', 'JavaScript async await', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'JS Session'])
+        
+        # Search
+        result = session_commands.handle_session_command(['search', 'Python'])
+        assert result is None  # Search displays results directly
+    
+    def test_export_json(self, session_commands):
+        """Test exporting session as JSON."""
+        # Create session
+        session_commands.add_message('user', 'Export me', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Export Test'])
+        
+        # Mock file operations
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value = Mock()
+            result = session_commands.handle_export_command(['json'])
+            assert result is None  # Export prints success message
+    
+    def test_export_markdown(self, session_commands):
+        """Test exporting session as Markdown."""
+        # Create session
+        session_commands.add_message('user', 'Export to MD', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'MD Export'])
+        
+        # Mock file operations
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value = Mock()
+            result = session_commands.handle_export_command(['markdown'])
+            assert result is None
+    
+    def test_export_invalid_format(self, session_commands):
+        """Test exporting with invalid format."""
+        result = session_commands.handle_export_command(['invalid'])
+        assert "Unknown export format: invalid" in result
+    
+    def test_find_session_by_id(self, session_commands):
+        """Test finding sessions by ID."""
+        # Create a session
+        session_commands.add_message('user', 'Find me', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Findable Session'])
+        session_id = session_commands.current_session_id
+        
+        # Find by partial ID
+        session = session_commands._find_session(session_id[:8])
+        assert session is not None
+        assert session.name == 'Findable Session'
+    
+    def test_find_session_by_name(self, session_commands):
+        """Test finding sessions by name."""
+        # Create sessions
+        session_commands.add_message('user', 'Test', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Unique Name'])
+        
+        # Find by exact name
+        session = session_commands._find_session('Unique Name')
+        assert session is not None
+        
+        # Find by partial name
+        session = session_commands._find_session('Unique')
+        assert session is not None
+        
+        # Case insensitive
+        session = session_commands._find_session('unique name')
+        assert session is not None
+    
+    def test_update_existing_session(self, session_commands):
+        """Test updating an existing session."""
+        # Create and save session
+        session_commands.add_message('user', 'Initial', {'provider': 'test', 'model': 'test'})
+        session_commands.handle_session_command(['save', 'Initial Name'])
+        session_id = session_commands.current_session_id
+        
+        # Add more messages and save with new name
+        session_commands.add_message('user', 'More content', {'provider': 'test', 'model': 'test'})
+        result = session_commands.handle_session_command(['save', 'Updated Name'])
+        
+        assert "Session updated: Updated Name" in result
+        assert session_commands.current_session_id == session_id
+    
+    def test_message_tracking(self, session_commands):
+        """Test that messages are properly tracked."""
+        # Add messages with metadata
+        session_commands.add_message(
+            'user',
+            'Test message',
+            {
+                'provider': 'oci_genai',
+                'model': 'cohere.command-r-plus',
+                'mode': 'code',
+                'custom_field': 'custom_value'
+            }
+        )
+        
+        assert len(session_commands.current_messages) == 1
+        msg = session_commands.current_messages[0]
+        assert msg['role'] == 'user'
+        assert msg['content'] == 'Test message'
+        assert msg['metadata']['provider'] == 'oci_genai'
+        assert msg['metadata']['custom_field'] == 'custom_value'
+    
+    def test_clear_conversation(self, session_commands):
+        """Test clearing conversation."""
+        # Add messages
+        session_commands.add_message('user', 'Message 1', {})
+        session_commands.add_message('assistant', 'Response 1', {})
+        assert len(session_commands.current_messages) == 2
+        
+        # Clear
+        session_commands.clear_conversation()
+        assert len(session_commands.current_messages) == 0
+        assert session_commands.current_session_id is None
+    
+    def test_get_context_messages(self, session_commands):
+        """Test getting context messages."""
+        # Without session (in-memory only)
+        session_commands.add_message('user', 'Test', {})
+        messages, truncated = session_commands.get_context_messages()
+        assert len(messages) == 1
+        assert not truncated
+        
+        # With saved session
+        session_commands.handle_session_command(['save', 'Context Test'])
+        messages, truncated = session_commands.get_context_messages(
+            model='gpt-3.5-turbo',
+            max_tokens=100
+        )
+        # Should use session manager's context windowing
+        assert isinstance(messages, list)

--- a/tests/session/test_commands.py
+++ b/tests/session/test_commands.py
@@ -41,15 +41,20 @@ class TestSessionCommands:
         result = session_commands.handle_session_command(['save', 'Test Session'])
         assert result == "No messages to save."
     
-    def test_save_and_load_session(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_save_and_load_session(self, mock_prompt, session_commands):
         """Test saving and loading a session."""
+        # Mock prompt to return empty description
+        mock_prompt.return_value = ""
+        
         # Add some messages
         session_commands.add_message('user', 'Hello', {'provider': 'test', 'model': 'test-model'})
         session_commands.add_message('assistant', 'Hi there!', {'provider': 'test', 'model': 'test-model'})
         
         # Save session
         result = session_commands.handle_session_command(['save', 'My Test Session'])
-        assert "Session saved: My Test Session" in result
+        # Could be either saved or updated depending on auto-save
+        assert ("Session saved: My Test Session" in result or "Session updated: My Test Session" in result)
         assert session_commands.current_session_id is not None
         
         # Clear and verify
@@ -62,8 +67,12 @@ class TestSessionCommands:
         assert len(session_commands.current_messages) == 2
         assert session_commands.current_messages[0]['content'] == 'Hello'
     
-    def test_list_sessions(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_list_sessions(self, mock_prompt, session_commands):
         """Test listing sessions."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create some sessions
         session_commands.add_message('user', 'Test 1', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'Session 1'])
@@ -76,8 +85,12 @@ class TestSessionCommands:
         result = session_commands.handle_session_command(['list'])
         assert result is None  # List displays table directly
     
-    def test_branch_session(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_branch_session(self, mock_prompt, session_commands):
         """Test branching from current session."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create and save initial session
         session_commands.add_message('user', 'Original message', {'provider': 'test', 'model': 'test'})
         session_commands.add_message('assistant', 'Original response', {'provider': 'test', 'model': 'test'})
@@ -91,32 +104,44 @@ class TestSessionCommands:
         parent_id = session_commands.current_session_id
         assert parent_id is not None
     
-    def test_delete_session(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_delete_session(self, mock_prompt, session_commands):
         """Test deleting a session."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create a session
         session_commands.add_message('user', 'Delete me', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'To Delete'])
         session_id = session_commands.current_session_id
         
         # Mock confirmation
-        with patch('rich.prompt.Confirm.ask', return_value=True):
+        with patch('coda.session.commands.Confirm.ask', return_value=True):
             result = session_commands.handle_session_command(['delete', 'To Delete'])
             assert "Session deleted: To Delete" in result
             assert session_commands.current_session_id is None
     
-    def test_delete_cancelled(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_delete_cancelled(self, mock_prompt, session_commands):
         """Test cancelling session deletion."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create a session
         session_commands.add_message('user', 'Keep me', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'To Keep'])
         
         # Mock confirmation denial
-        with patch('rich.prompt.Confirm.ask', return_value=False):
+        with patch('coda.session.commands.Confirm.ask', return_value=False):
             result = session_commands.handle_session_command(['delete', 'To Keep'])
             assert result == "Deletion cancelled."
     
-    def test_session_info(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_session_info(self, mock_prompt, session_commands):
         """Test displaying session information."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create a session with some data
         session_commands.add_message('user', 'Info test', {
             'provider': 'test_provider',
@@ -129,8 +154,12 @@ class TestSessionCommands:
         result = session_commands.handle_session_command(['info'])
         assert result is None  # Info displays panel directly
     
-    def test_search_sessions(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_search_sessions(self, mock_prompt, session_commands):
         """Test searching across sessions."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create sessions with searchable content
         session_commands.add_message('user', 'Python programming question', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'Python Session'])
@@ -143,8 +172,12 @@ class TestSessionCommands:
         result = session_commands.handle_session_command(['search', 'Python'])
         assert result is None  # Search displays results directly
     
-    def test_export_json(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_export_json(self, mock_prompt, session_commands):
         """Test exporting session as JSON."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create session
         session_commands.add_message('user', 'Export me', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'Export Test'])
@@ -155,8 +188,12 @@ class TestSessionCommands:
             result = session_commands.handle_export_command(['json'])
             assert result is None  # Export prints success message
     
-    def test_export_markdown(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_export_markdown(self, mock_prompt, session_commands):
         """Test exporting session as Markdown."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create session
         session_commands.add_message('user', 'Export to MD', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'MD Export'])
@@ -172,8 +209,12 @@ class TestSessionCommands:
         result = session_commands.handle_export_command(['invalid'])
         assert "Unknown export format: invalid" in result
     
-    def test_find_session_by_id(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_find_session_by_id(self, mock_prompt, session_commands):
         """Test finding sessions by ID."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create a session
         session_commands.add_message('user', 'Find me', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'Findable Session'])
@@ -184,8 +225,12 @@ class TestSessionCommands:
         assert session is not None
         assert session.name == 'Findable Session'
     
-    def test_find_session_by_name(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_find_session_by_name(self, mock_prompt, session_commands):
         """Test finding sessions by name."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create sessions
         session_commands.add_message('user', 'Test', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'Unique Name'])
@@ -202,8 +247,12 @@ class TestSessionCommands:
         session = session_commands._find_session('unique name')
         assert session is not None
     
-    def test_update_existing_session(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_update_existing_session(self, mock_prompt, session_commands):
         """Test updating an existing session."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Create and save session
         session_commands.add_message('user', 'Initial', {'provider': 'test', 'model': 'test'})
         session_commands.handle_session_command(['save', 'Initial Name'])
@@ -249,8 +298,12 @@ class TestSessionCommands:
         assert len(session_commands.current_messages) == 0
         assert session_commands.current_session_id is None
     
-    def test_get_context_messages(self, session_commands):
+    @patch('coda.session.commands.Prompt.ask')
+    def test_get_context_messages(self, mock_prompt, session_commands):
         """Test getting context messages."""
+        # Mock prompts
+        mock_prompt.return_value = ""
+        
         # Without session (in-memory only)
         session_commands.add_message('user', 'Test', {})
         messages, truncated = session_commands.get_context_messages()

--- a/tests/session/test_context.py
+++ b/tests/session/test_context.py
@@ -1,0 +1,195 @@
+"""Tests for context management functionality."""
+
+import pytest
+
+from coda.session.context import ContextManager, ContextWindow
+
+
+class TestContextManager:
+    """Test context management and windowing."""
+    
+    @pytest.fixture
+    def context_manager(self):
+        """Create a context manager instance."""
+        return ContextManager()
+    
+    def test_token_counting(self, context_manager):
+        """Test token counting functionality."""
+        # Test basic counting
+        text = "Hello world"
+        tokens = context_manager.count_tokens(text)
+        assert tokens > 0
+        assert tokens < 10  # Should be around 2-3 tokens
+        
+        # Test longer text
+        long_text = "The quick brown fox jumps over the lazy dog " * 10
+        long_tokens = context_manager.count_tokens(long_text)
+        assert long_tokens > tokens
+    
+    def test_message_token_counting(self, context_manager):
+        """Test counting tokens in messages."""
+        message = {
+            'role': 'user',
+            'content': 'What is Python?'
+        }
+        
+        tokens = context_manager.count_message_tokens(message)
+        assert tokens > 4  # Should include overhead + content
+    
+    def test_model_context_limits(self, context_manager):
+        """Test retrieving model context limits."""
+        # Test known models
+        assert context_manager.get_model_context_limit("gpt-4") == 8192
+        assert context_manager.get_model_context_limit("gpt-4-32k") == 32768
+        assert context_manager.get_model_context_limit("cohere.command-r-plus") == 128000
+        assert context_manager.get_model_context_limit("meta.llama-3.1-405b") == 128000
+        
+        # Test partial matching
+        assert context_manager.get_model_context_limit("gpt-4-turbo-preview") == 128000
+        
+        # Test unknown model
+        assert context_manager.get_model_context_limit("unknown-model") == 4096
+    
+    def test_context_optimization(self, context_manager):
+        """Test context optimization with token limits."""
+        # Create messages
+        messages = []
+        for i in range(20):
+            messages.append({
+                'role': 'user' if i % 2 == 0 else 'assistant',
+                'content': f'Message {i}: ' + 'x' * 100
+            })
+        
+        # Add system message
+        messages.insert(0, {
+            'role': 'system',
+            'content': 'You are a helpful assistant.'
+        })
+        
+        # Optimize with tight limit
+        optimized, was_truncated = context_manager.optimize_context(
+            messages,
+            model='gpt-3.5-turbo',
+            target_tokens=500,
+            preserve_last_n=5
+        )
+        
+        assert was_truncated
+        assert len(optimized) < len(messages)
+        
+        # System message should be preserved
+        assert any(msg['role'] == 'system' for msg in optimized)
+        
+        # Recent messages should be preserved
+        last_contents = [msg['content'] for msg in messages[-5:] if msg['role'] != 'system']
+        optimized_contents = [msg['content'] for msg in optimized]
+        for content in last_contents:
+            assert content in optimized_contents
+    
+    def test_no_truncation_needed(self, context_manager):
+        """Test when messages fit within limit."""
+        messages = [
+            {'role': 'user', 'content': 'Hello'},
+            {'role': 'assistant', 'content': 'Hi there!'}
+        ]
+        
+        optimized, was_truncated = context_manager.optimize_context(
+            messages,
+            model='gpt-4',
+            target_tokens=1000
+        )
+        
+        assert not was_truncated
+        assert len(optimized) == len(messages)
+        assert optimized == messages
+    
+    def test_summary_message_creation(self, context_manager):
+        """Test creating summary messages."""
+        messages = [
+            {'role': 'user', 'content': 'Tell me about functions in Python'},
+            {'role': 'assistant', 'content': 'Functions are reusable blocks of code...'},
+            {'role': 'user', 'content': 'What about classes?'},
+            {'role': 'assistant', 'content': 'Classes are blueprints for objects...'},
+            {'role': 'user', 'content': 'How do I handle errors?'},
+            {'role': 'assistant', 'content': 'Use try-except blocks for error handling...'}
+        ]
+        
+        summary = context_manager.create_summary_message(messages)
+        
+        assert summary['role'] == 'system'
+        assert 'Previous conversation summary' in summary['content']
+        assert '6 messages' in summary['content']
+        assert '3 user, 3 assistant' in summary['content']
+    
+    def test_key_topic_extraction(self, context_manager):
+        """Test extracting key topics from messages."""
+        messages = [
+            {'role': 'user', 'content': 'How do I create a function in Python?'},
+            {'role': 'assistant', 'content': 'To create a function, use the def keyword...'},
+            {'role': 'user', 'content': 'What about error handling with functions?'},
+            {'role': 'assistant', 'content': 'You can handle errors in functions using try-except...'},
+            {'role': 'user', 'content': 'Can functions access database connections?'},
+            {'role': 'assistant', 'content': 'Yes, functions can work with database connections...'}
+        ]
+        
+        topics = context_manager._extract_key_topics(messages)
+        
+        assert 'function' in topics
+        assert 'error' in topics
+        assert 'database' in topics
+        assert len(topics) <= 5
+    
+    def test_context_window_modes(self, context_manager):
+        """Test different context window modes."""
+        # Test aggressive mode
+        aggressive = context_manager.get_context_window("gpt-4", mode="aggressive")
+        assert aggressive.max_tokens == int(8192 * 0.9)
+        assert aggressive.max_messages == 100
+        assert aggressive.preserve_system
+        
+        # Test balanced mode
+        balanced = context_manager.get_context_window("gpt-4", mode="balanced")
+        assert balanced.max_tokens == int(8192 * 0.75)
+        assert balanced.max_messages == 50
+        
+        # Test conservative mode
+        conservative = context_manager.get_context_window("gpt-4", mode="conservative")
+        assert conservative.max_tokens == int(8192 * 0.6)
+        assert conservative.max_messages == 30
+    
+    def test_empty_messages(self, context_manager):
+        """Test handling empty message lists."""
+        optimized, was_truncated = context_manager.optimize_context(
+            [],
+            model='gpt-4',
+            target_tokens=1000
+        )
+        
+        assert optimized == []
+        assert not was_truncated
+    
+    def test_system_message_preservation(self, context_manager):
+        """Test that system messages are always preserved."""
+        messages = [
+            {'role': 'system', 'content': 'Important system prompt'},
+            {'role': 'user', 'content': 'x' * 1000},
+            {'role': 'assistant', 'content': 'y' * 1000},
+            {'role': 'system', 'content': 'Another system message'},
+            {'role': 'user', 'content': 'z' * 1000}
+        ]
+        
+        # Optimize with very tight limit
+        optimized, was_truncated = context_manager.optimize_context(
+            messages,
+            model='gpt-3.5-turbo',
+            target_tokens=200,
+            preserve_last_n=1
+        )
+        
+        assert was_truncated
+        
+        # All system messages should be preserved
+        system_messages = [msg for msg in optimized if msg['role'] == 'system']
+        assert len(system_messages) == 2
+        assert system_messages[0]['content'] == 'Important system prompt'
+        assert system_messages[1]['content'] == 'Another system message'

--- a/tests/session/test_context.py
+++ b/tests/session/test_context.py
@@ -57,7 +57,7 @@ class TestContextManager:
         for i in range(20):
             messages.append({
                 'role': 'user' if i % 2 == 0 else 'assistant',
-                'content': f'Message {i}: ' + 'x' * 100
+                'content': f'Message {i}: ' + 'x' * 200  # Increased from 100 to 200
             })
         
         # Add system message

--- a/tests/session/test_database.py
+++ b/tests/session/test_database.py
@@ -230,6 +230,11 @@ class TestSessionDatabase:
             db.add(session)
             db.commit()
         
+        # Force WAL checkpoint to ensure data is written to main database
+        with temp_db.engine.connect() as conn:
+            conn.execute(text("PRAGMA wal_checkpoint(TRUNCATE)"))
+            conn.commit()
+        
         # Create backup
         with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
             backup_path = Path(f.name)

--- a/tests/session/test_database.py
+++ b/tests/session/test_database.py
@@ -1,0 +1,250 @@
+"""Tests for session database functionality."""
+
+import tempfile
+from pathlib import Path
+import pytest
+from sqlalchemy import text
+
+from coda.session.database import SessionDatabase
+from coda.session.models import Session, Message, Tag
+
+
+class TestSessionDatabase:
+    """Test session database operations."""
+    
+    @pytest.fixture
+    def temp_db(self):
+        """Create a temporary database for testing."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        
+        db = SessionDatabase(db_path)
+        yield db
+        
+        # Cleanup
+        db.close()
+        db_path.unlink()
+    
+    def test_database_creation(self, temp_db):
+        """Test that database and tables are created correctly."""
+        # Check that database file exists
+        assert temp_db.db_path.exists()
+        
+        # Check tables exist
+        with temp_db.engine.connect() as conn:
+            result = conn.execute(text(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ))
+            tables = [row[0] for row in result]
+            
+            assert 'sessions' in tables
+            assert 'messages' in tables
+            assert 'tags' in tables
+            assert 'attachments' in tables
+            assert 'search_index' in tables
+            assert 'messages_fts' in tables
+    
+    def test_session_creation(self, temp_db):
+        """Test creating a session."""
+        with temp_db.get_session() as db:
+            session = Session(
+                name="Test Session",
+                provider="test_provider",
+                model="test_model"
+            )
+            db.add(session)
+            db.commit()
+            
+            # Verify session was created
+            saved_session = db.query(Session).filter_by(name="Test Session").first()
+            assert saved_session is not None
+            assert saved_session.provider == "test_provider"
+            assert saved_session.model == "test_model"
+            assert saved_session.message_count == 0
+    
+    def test_message_creation(self, temp_db):
+        """Test creating messages."""
+        with temp_db.get_session() as db:
+            # Create session first
+            session = Session(
+                name="Test Session",
+                provider="test_provider",
+                model="test_model"
+            )
+            db.add(session)
+            db.commit()
+            
+            # Create messages
+            msg1 = Message(
+                session_id=session.id,
+                sequence=1,
+                role="user",
+                content="Hello, world!"
+            )
+            msg2 = Message(
+                session_id=session.id,
+                sequence=2,
+                role="assistant",
+                content="Hello! How can I help you?"
+            )
+            db.add(msg1)
+            db.add(msg2)
+            db.commit()
+            
+            # Verify messages
+            messages = db.query(Message).filter_by(session_id=session.id).all()
+            assert len(messages) == 2
+            assert messages[0].content == "Hello, world!"
+            assert messages[1].role == "assistant"
+    
+    def test_fts_index(self, temp_db):
+        """Test full-text search functionality."""
+        with temp_db.get_session() as db:
+            # Create session and message
+            session = Session(
+                name="Test Session",
+                provider="test_provider",
+                model="test_model"
+            )
+            db.add(session)
+            db.commit()
+            
+            message = Message(
+                session_id=session.id,
+                sequence=1,
+                role="user",
+                content="Python programming with SQLite database"
+            )
+            db.add(message)
+            db.commit()
+            
+            # Add to FTS index
+            db.execute(text("""
+                INSERT INTO messages_fts (message_id, session_id, content, role)
+                VALUES (:msg_id, :session_id, :content, :role)
+            """), {
+                'msg_id': message.id,
+                'session_id': session.id,
+                'content': message.content,
+                'role': message.role
+            })
+            db.commit()
+            
+            # Search
+            result = db.execute(text("""
+                SELECT message_id FROM messages_fts
+                WHERE messages_fts MATCH 'SQLite'
+            """)).fetchall()
+            
+            assert len(result) == 1
+            assert result[0][0] == message.id
+    
+    def test_tag_relationships(self, temp_db):
+        """Test tag relationships with sessions."""
+        with temp_db.get_session() as db:
+            # Create session and tags
+            session = Session(
+                name="Test Session",
+                provider="test_provider",
+                model="test_model"
+            )
+            tag1 = Tag(name="python")
+            tag2 = Tag(name="database")
+            
+            session.tags.append(tag1)
+            session.tags.append(tag2)
+            
+            db.add(session)
+            db.commit()
+            
+            # Verify relationships
+            saved_session = db.query(Session).filter_by(name="Test Session").first()
+            assert len(saved_session.tags) == 2
+            assert {tag.name for tag in saved_session.tags} == {"python", "database"}
+    
+    def test_session_branching(self, temp_db):
+        """Test session parent-child relationships."""
+        with temp_db.get_session() as db:
+            # Create parent session
+            parent = Session(
+                name="Parent Session",
+                provider="test_provider",
+                model="test_model"
+            )
+            db.add(parent)
+            db.commit()
+            
+            # Create branch
+            branch = Session(
+                name="Branch Session",
+                provider="test_provider",
+                model="test_model",
+                parent_id=parent.id
+            )
+            db.add(branch)
+            db.commit()
+            
+            # Verify relationship
+            saved_parent = db.query(Session).filter_by(id=parent.id).first()
+            assert len(saved_parent.branches) == 1
+            assert saved_parent.branches[0].name == "Branch Session"
+            
+            saved_branch = db.query(Session).filter_by(id=branch.id).first()
+            assert saved_branch.parent.name == "Parent Session"
+    
+    def test_vacuum(self, temp_db):
+        """Test database vacuum operation."""
+        initial_size = temp_db.get_db_size()
+        
+        # Create and delete some data
+        with temp_db.get_session() as db:
+            for i in range(10):
+                session = Session(
+                    name=f"Session {i}",
+                    provider="test",
+                    model="test"
+                )
+                db.add(session)
+            db.commit()
+            
+            # Delete all sessions
+            db.query(Session).delete()
+            db.commit()
+        
+        # Run vacuum
+        temp_db.vacuum()
+        
+        # Size should be similar to initial (not much larger)
+        final_size = temp_db.get_db_size()
+        assert final_size < initial_size + 10000  # Allow 10KB growth
+    
+    def test_backup(self, temp_db):
+        """Test database backup functionality."""
+        # Create some data
+        with temp_db.get_session() as db:
+            session = Session(
+                name="Backup Test",
+                provider="test",
+                model="test"
+            )
+            db.add(session)
+            db.commit()
+        
+        # Create backup
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            backup_path = Path(f.name)
+        
+        temp_db.backup(backup_path)
+        
+        # Verify backup exists and contains data
+        assert backup_path.exists()
+        
+        # Open backup and check data
+        backup_db = SessionDatabase(backup_path)
+        with backup_db.get_session() as db:
+            session = db.query(Session).filter_by(name="Backup Test").first()
+            assert session is not None
+        
+        # Cleanup
+        backup_db.close()
+        backup_path.unlink()

--- a/tests/session/test_end_to_end.py
+++ b/tests/session/test_end_to_end.py
@@ -1,0 +1,268 @@
+"""End-to-end tests demonstrating complete session functionality."""
+
+import tempfile
+from pathlib import Path
+import pytest
+
+from coda.providers import MockProvider, Message, Role
+from coda.session import SessionDatabase, SessionManager, SessionCommands
+
+
+class TestSessionEndToEnd:
+    """End-to-end tests for session management functionality."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    def test_complete_session_lifecycle_with_conversation_continuity(self, temp_db_path):
+        """
+        Test the complete session lifecycle including the key fix:
+        conversation continuity after loading sessions.
+        
+        This test demonstrates that the original issue is resolved:
+        - Save conversation
+        - Clear conversation (AI loses memory)
+        - Load conversation (AI regains memory)
+        - Continue conversation naturally
+        """
+        # Initialize components
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        commands = SessionCommands(manager)
+        provider = MockProvider()
+        
+        try:
+            # === STEP 1: Create conversation ===
+            print("\n🎬 STEP 1: Creating conversation about Python")
+            
+            # Simulate CLI conversation state
+            cli_messages = []
+            
+            # User asks about Python
+            user_msg1 = Message(role=Role.USER, content="What is Python?")
+            cli_messages.append(user_msg1)
+            
+            # AI responds (using full conversation context)
+            ai_response1 = provider.chat(cli_messages, "mock-echo")
+            assistant_msg1 = Message(role=Role.ASSISTANT, content=ai_response1)
+            cli_messages.append(assistant_msg1)
+            
+            # User asks about decorators
+            user_msg2 = Message(role=Role.USER, content="Tell me about Python decorators")
+            cli_messages.append(user_msg2)
+            
+            # AI responds with context
+            ai_response2 = provider.chat(cli_messages, "mock-echo")
+            assistant_msg2 = Message(role=Role.ASSISTANT, content=ai_response2)
+            cli_messages.append(assistant_msg2)
+            
+            print(f"  Created conversation with {len(cli_messages)} messages")
+            print(f"  AI knows about: Python, decorators")
+            
+            # Track in session commands
+            commands.add_message('user', user_msg1.content, {'provider': 'mock'})
+            commands.add_message('assistant', ai_response1, {'provider': 'mock'})
+            commands.add_message('user', user_msg2.content, {'provider': 'mock'})
+            commands.add_message('assistant', ai_response2, {'provider': 'mock'})
+            
+            # === STEP 2: Save session ===
+            print("\n💾 STEP 2: Saving session to database")
+            
+            session = manager.create_session(
+                name="Python Tutorial",
+                provider="mock",
+                model="mock-echo",
+                description="Testing conversation continuity"
+            )
+            
+            # Save all messages to database
+            for msg_data in commands.current_messages:
+                manager.add_message(
+                    session_id=session.id,
+                    role=msg_data['role'],
+                    content=msg_data['content'],
+                    metadata=msg_data.get('metadata', {}),
+                    provider=msg_data['metadata'].get('provider'),
+                    model=msg_data['metadata'].get('model')
+                )
+            
+            commands.current_session_id = session.id
+            print(f"  Session saved: {session.name} (ID: {session.id[:8]}...)")
+            
+            # === STEP 3: Clear conversation (lose memory) ===
+            print("\n🧹 STEP 3: Clearing conversation (AI loses memory)")
+            
+            # Clear everything
+            cli_messages.clear()
+            commands.clear_conversation()
+            
+            # Test that AI has no memory
+            test_msg = Message(role=Role.USER, content="What were we discussing about decorators?")
+            no_memory_response = provider.chat([test_msg], "mock-echo")
+            
+            has_memory = any(word in no_memory_response.lower() for word in ['python', 'decorator'])
+            assert not has_memory, f"AI should have no memory after clear: {no_memory_response}"
+            
+            print(f"  ✓ AI has no memory: '{no_memory_response[:50]}...'")
+            
+            # === STEP 4: Load session (restore memory) ===
+            print("\n📂 STEP 4: Loading session (AI regains memory)")
+            
+            # Load session (simulating the CLI integration)
+            session_loaded = manager.get_session(session.id)
+            messages_from_db = manager.get_messages(session.id)
+            
+            # Convert to CLI format and restore
+            commands.current_messages = []
+            for msg in messages_from_db:
+                commands.current_messages.append({
+                    'role': msg.role,
+                    'content': msg.content,
+                    'metadata': {'provider': msg.provider, 'model': msg.model}
+                })
+            
+            commands.current_session_id = session.id
+            commands._messages_loaded = True
+            
+            # Get messages for CLI (this is the key fix)
+            restored_messages = commands.get_loaded_messages_for_cli()
+            cli_messages.clear()
+            cli_messages.extend(restored_messages)
+            
+            print(f"  ✓ Restored {len(cli_messages)} messages to CLI")
+            
+            # === STEP 5: Test memory restoration ===
+            print("\n🧠 STEP 5: Testing AI memory restoration")
+            
+            # Ask about previous conversation
+            memory_test = Message(role=Role.USER, content="What were we discussing about decorators?")
+            cli_messages.append(memory_test)
+            
+            # AI should now remember the context
+            memory_response = provider.chat(cli_messages, "mock-echo")
+            
+            has_context = any(word in memory_response.lower() for word in ['python', 'decorator', 'function'])
+            assert has_context, f"AI should remember context after load: {memory_response}"
+            
+            print(f"  ✓ AI remembers context: '{memory_response[:50]}...'")
+            
+            # === STEP 6: Continue conversation naturally ===
+            print("\n💬 STEP 6: Continuing conversation naturally")
+            
+            # Remove test message, add AI response
+            cli_messages.pop()
+            cli_messages.append(Message(role=Role.ASSISTANT, content=memory_response))
+            
+            # Ask follow-up question
+            followup = Message(role=Role.USER, content="Can you show me a decorator example?")
+            cli_messages.append(followup)
+            
+            followup_response = provider.chat(cli_messages, "mock-echo")
+            
+            # Should continue conversation about decorators
+            continues_topic = any(word in followup_response.lower() for word in ['decorator', 'python', '@'])
+            assert continues_topic, f"Should continue decorator topic: {followup_response}"
+            
+            print(f"  ✓ Conversation continues: '{followup_response[:50]}...'")
+            
+            # === STEP 7: Verify session integrity ===
+            print("\n🔍 STEP 7: Verifying session integrity")
+            
+            # Check session data
+            saved_messages = manager.get_messages(session.id)
+            assert len(saved_messages) == 4, "Should have 4 saved messages"
+            
+            # Check export functionality
+            json_export = manager.export_session(session.id, 'json')
+            assert "Python" in json_export and "decorator" in json_export
+            
+            # Check search functionality
+            search_results = manager.search_sessions("decorator")
+            assert len(search_results) == 1, "Should find session in search"
+            
+            print(f"  ✓ Session integrity verified")
+            
+            print("\n🎉 SUCCESS: Complete session lifecycle with conversation continuity!")
+            print("     The original issue has been resolved:")
+            print("     ✓ Sessions save correctly")
+            print("     ✓ Conversations clear completely")
+            print("     ✓ Sessions load with full context restoration")
+            print("     ✓ AI remembers previous conversations")
+            print("     ✓ Conversations continue naturally")
+            
+            return True
+            
+        finally:
+            db.close()
+    
+    def test_session_branching_preserves_context(self, temp_db_path):
+        """Test that session branching maintains conversation context."""
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        provider = MockProvider()
+        
+        try:
+            # Create original session
+            session = manager.create_session("Original", "mock", "mock-echo")
+            
+            # Add conversation
+            msg1 = manager.add_message(session.id, "user", "What is Python?")
+            manager.add_message(session.id, "assistant", "Python is a programming language")
+            msg2 = manager.add_message(session.id, "user", "What about JavaScript?")
+            manager.add_message(session.id, "assistant", "JavaScript is for web development")
+            
+            # Create branch from first question
+            branch = manager.create_session(
+                "Python Focus",
+                "mock", 
+                "mock-echo",
+                parent_id=session.id,
+                branch_point_message_id=msg1.id
+            )
+            
+            # Get branch context
+            context, _ = manager.get_session_context(branch.id)
+            assert len(context) == 2  # Up to branch point
+            
+            # Test AI context in branch
+            messages = [Message(role=Role(msg['role']), content=msg['content']) for msg in context]
+            messages.append(Message(role=Role.USER, content="Tell me more about Python decorators"))
+            
+            response = provider.chat(messages, "mock-echo")
+            
+            # Should focus on Python (not JavaScript)
+            assert "python" in response.lower()
+            assert "javascript" not in response.lower()
+            
+        finally:
+            db.close()
+    
+    def test_mock_provider_conversation_patterns(self, temp_db_path):
+        """Test mock provider's conversation awareness patterns."""
+        provider = MockProvider()
+        
+        # Test topic recognition
+        messages = [Message(role=Role.USER, content="Tell me about Python")]
+        response = provider.chat(messages, "mock-echo")
+        assert "python" in response.lower() and "programming" in response.lower()
+        
+        # Test memory questions
+        conversation = [
+            Message(role=Role.USER, content="What is Python?"),
+            Message(role=Role.ASSISTANT, content="Python is a language"),
+            Message(role=Role.USER, content="What about decorators?"),
+            Message(role=Role.ASSISTANT, content="Decorators modify functions"),
+            Message(role=Role.USER, content="What were we discussing?")
+        ]
+        
+        memory_response = provider.chat(conversation, "mock-echo")
+        assert any(word in memory_response.lower() for word in ['python', 'decorator'])
+        
+        # Test context building
+        assert provider.conversation_history == conversation

--- a/tests/session/test_end_to_end.py
+++ b/tests/session/test_end_to_end.py
@@ -184,7 +184,10 @@ class TestSessionEndToEnd:
             
             # Check search functionality
             search_results = manager.search_sessions("decorator")
-            assert len(search_results) == 1, "Should find session in search"
+            assert len(search_results) >= 1, "Should find at least one session in search"
+            # Verify our named session is in the results
+            named_session_found = any(session.name == "Python Tutorial" for session, _ in search_results)
+            assert named_session_found, "Should find our named session in search results"
             
             print(f"  ✓ Session integrity verified")
             
@@ -213,17 +216,17 @@ class TestSessionEndToEnd:
             
             # Add conversation
             msg1 = manager.add_message(session.id, "user", "What is Python?")
-            manager.add_message(session.id, "assistant", "Python is a programming language")
+            msg1_response = manager.add_message(session.id, "assistant", "Python is a programming language")
             msg2 = manager.add_message(session.id, "user", "What about JavaScript?")
             manager.add_message(session.id, "assistant", "JavaScript is for web development")
             
-            # Create branch from first question
+            # Create branch from first answer (to include both Q&A)
             branch = manager.create_session(
                 "Python Focus",
                 "mock", 
                 "mock-echo",
                 parent_id=session.id,
-                branch_point_message_id=msg1.id
+                branch_point_message_id=msg1_response.id
             )
             
             # Get branch context

--- a/tests/session/test_interactive_integration.py
+++ b/tests/session/test_interactive_integration.py
@@ -91,7 +91,7 @@ class TestInteractiveSessionIntegration:
         with patch('rich.prompt.Prompt.ask', return_value=""):
             result = cli.session_commands.handle_session_command(['save', 'Test Session'])
         
-        assert "Session saved" in result
+        assert ("Session saved" in result or "Session updated" in result)
         session_id = cli.session_commands.current_session_id
         assert session_id is not None
         
@@ -173,7 +173,7 @@ class TestInteractiveSessionIntegration:
         # Test save
         with patch('rich.prompt.Prompt.ask', return_value=""):
             result = cli.session_commands.handle_session_command(['save', 'CLI Test'])
-        assert "Session saved" in result
+        assert ("Session saved" in result or "Session updated" in result)
         
         # Test list
         result = cli.session_commands.handle_session_command(['list'])

--- a/tests/session/test_interactive_integration.py
+++ b/tests/session/test_interactive_integration.py
@@ -1,0 +1,269 @@
+"""Interactive session integration tests with mock provider."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+from coda.providers import MockProvider, Message, Role
+from coda.cli.interactive_cli import InteractiveCLI
+from coda.session import SessionCommands, SessionManager, SessionDatabase
+
+
+class TestInteractiveSessionIntegration:
+    """Test interactive CLI session management integration."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    @pytest.fixture
+    def setup_interactive_cli(self, temp_db_path):
+        """Set up interactive CLI with session management."""
+        # Initialize components
+        mock_provider = MockProvider()
+        cli = InteractiveCLI()
+        
+        # Create session database and manager
+        db = SessionDatabase(temp_db_path)
+        session_manager = SessionManager(db)
+        cli.session_commands = SessionCommands(session_manager)
+        
+        # Set up provider info
+        models = mock_provider.list_models()
+        cli.set_provider_info("mock", mock_provider, None, "mock-echo", models)
+        
+        yield cli, mock_provider, db
+        
+        db.close()
+    
+    def test_complete_session_workflow(self, setup_interactive_cli):
+        """Test complete session workflow: chat -> save -> clear -> load -> continue."""
+        cli, mock_provider, db = setup_interactive_cli
+        
+        # Simulate conversation messages (as interactive.py maintains them)
+        cli_messages = []
+        
+        # === Phase 1: Start conversation ===
+        user_msg = Message(role=Role.USER, content="What is Python?")
+        cli_messages.append(user_msg)
+        
+        # Track in session commands
+        cli.session_commands.add_message('user', 'What is Python?', {
+            'provider': 'mock',
+            'model': 'mock-echo',
+            'mode': 'general'
+        })
+        
+        # Get AI response
+        ai_response = mock_provider.chat(cli_messages, "mock-echo")
+        assistant_msg = Message(role=Role.ASSISTANT, content=ai_response)
+        cli_messages.append(assistant_msg)
+        
+        # Track response
+        cli.session_commands.add_message('assistant', ai_response, {
+            'provider': 'mock',
+            'model': 'mock-echo'
+        })
+        
+        assert len(cli_messages) == 2
+        assert "Python" in ai_response
+        
+        # === Phase 2: Continue conversation ===
+        user_msg2 = Message(role=Role.USER, content="Tell me about decorators")
+        cli_messages.append(user_msg2)
+        cli.session_commands.add_message('user', 'Tell me about decorators', {'provider': 'mock'})
+        
+        ai_response2 = mock_provider.chat(cli_messages, "mock-echo")
+        assistant_msg2 = Message(role=Role.ASSISTANT, content=ai_response2)
+        cli_messages.append(assistant_msg2)
+        cli.session_commands.add_message('assistant', ai_response2, {'provider': 'mock'})
+        
+        assert len(cli_messages) == 4
+        assert "decorator" in ai_response2.lower()
+        
+        # === Phase 3: Save session ===
+        with patch('rich.prompt.Prompt.ask', return_value=""):
+            result = cli.session_commands.handle_session_command(['save', 'Test Session'])
+        
+        assert "Session saved" in result
+        session_id = cli.session_commands.current_session_id
+        assert session_id is not None
+        
+        # === Phase 4: Clear conversation ===
+        original_message_count = len(cli_messages)
+        
+        # Simulate /clear command
+        cli.session_commands.clear_conversation()
+        was_cleared = cli.session_commands.was_conversation_cleared()
+        
+        # Simulate CLI clearing its messages
+        if was_cleared:
+            cli_messages.clear()
+        
+        assert len(cli_messages) == 0
+        assert len(cli.session_commands.current_messages) == 0
+        assert was_cleared
+        
+        # === Phase 5: Test AI has no memory ===
+        test_msg = Message(role=Role.USER, content="What were we discussing?")
+        cli_messages.append(test_msg)
+        
+        no_memory_response = mock_provider.chat(cli_messages, "mock-echo")
+        
+        # Should not remember previous conversation
+        has_memory = any(word in no_memory_response.lower() for word in ['python', 'decorator'])
+        assert not has_memory, f"AI should not remember previous conversation: {no_memory_response}"
+        
+        # Remove test message
+        cli_messages.pop()
+        
+        # === Phase 6: Load session ===
+        result = cli.session_commands.handle_session_command(['load', 'Test Session'])
+        assert result is None  # Load prints directly
+        
+        # Check if messages were loaded
+        loaded_messages = cli.session_commands.get_loaded_messages_for_cli()
+        assert len(loaded_messages) == original_message_count
+        
+        # Simulate the CLI integration (from interactive.py)
+        if loaded_messages:
+            cli_messages.clear()
+            cli_messages.extend(loaded_messages)
+        
+        assert len(cli_messages) == original_message_count
+        
+        # === Phase 7: Test AI memory restoration ===
+        memory_test_msg = Message(role=Role.USER, content="What were we discussing about decorators?")
+        cli_messages.append(memory_test_msg)
+        
+        memory_response = mock_provider.chat(cli_messages, "mock-echo")
+        
+        # Should remember previous conversation
+        has_context = any(word in memory_response.lower() for word in ['python', 'decorator', 'function', 'modify'])
+        assert has_context, f"AI should remember context after loading: {memory_response}"
+        
+        # === Phase 8: Continue conversation ===
+        # Remove test message, add AI response
+        cli_messages.pop()
+        cli_messages.append(Message(role=Role.ASSISTANT, content=memory_response))
+        
+        # Add new question
+        followup_msg = Message(role=Role.USER, content="Can you show me a decorator example?")
+        cli_messages.append(followup_msg)
+        
+        followup_response = mock_provider.chat(cli_messages, "mock-echo")
+        
+        # Should continue conversation naturally
+        assert "decorator" in followup_response.lower() or "python" in followup_response.lower()
+    
+    def test_session_commands_integration(self, setup_interactive_cli):
+        """Test session commands work correctly with CLI."""
+        cli, mock_provider, db = setup_interactive_cli
+        
+        # Add messages
+        cli.session_commands.add_message('user', 'Hello', {'provider': 'mock'})
+        cli.session_commands.add_message('assistant', 'Hi there!', {'provider': 'mock'})
+        
+        # Test save
+        with patch('rich.prompt.Prompt.ask', return_value=""):
+            result = cli.session_commands.handle_session_command(['save', 'CLI Test'])
+        assert "Session saved" in result
+        
+        # Test list
+        result = cli.session_commands.handle_session_command(['list'])
+        assert result is None  # List displays table
+        
+        # Test clear
+        cli.session_commands.clear_conversation()
+        assert len(cli.session_commands.current_messages) == 0
+        
+        # Test load
+        result = cli.session_commands.handle_session_command(['load', 'CLI Test'])
+        assert result is None  # Load displays info
+        assert len(cli.session_commands.current_messages) == 2
+    
+    def test_mock_provider_context_awareness(self, setup_interactive_cli):
+        """Test mock provider correctly maintains conversation context."""
+        cli, mock_provider, db = setup_interactive_cli
+        
+        # Build conversation
+        messages = [
+            Message(role=Role.USER, content="What is Python?"),
+            Message(role=Role.ASSISTANT, content="Python is a programming language"),
+            Message(role=Role.USER, content="Tell me about decorators"),
+            Message(role=Role.ASSISTANT, content="Decorators modify functions"),
+        ]
+        
+        # Test context-aware response
+        messages.append(Message(role=Role.USER, content="What were we discussing about decorators?"))
+        response = mock_provider.chat(messages, "mock-echo")
+        
+        # Should reference previous conversation
+        context_indicators = ['decorator', 'python', 'function', 'modify', 'syntax']
+        has_context = any(indicator in response.lower() for indicator in context_indicators)
+        assert has_context, f"Mock provider should show context awareness: {response}"
+        
+        # Test without context
+        no_context_messages = [Message(role=Role.USER, content="What were we discussing?")]
+        no_context_response = mock_provider.chat(no_context_messages, "mock-echo")
+        
+        # Should not reference specific topics
+        has_specific_context = any(word in no_context_response.lower() for word in ['python', 'decorator'])
+        assert not has_specific_context, f"Without context, should not reference specific topics: {no_context_response}"
+    
+    def test_session_export_with_interactive_data(self, setup_interactive_cli):
+        """Test session export contains correct interactive conversation data."""
+        cli, mock_provider, db = setup_interactive_cli
+        
+        # Create conversation
+        cli.session_commands.add_message('user', 'Test export message', {'provider': 'mock'})
+        cli.session_commands.add_message('assistant', 'Export response', {'provider': 'mock'})
+        
+        # Save session
+        with patch('rich.prompt.Prompt.ask', return_value=""):
+            cli.session_commands.handle_session_command(['save', 'Export Test'])
+        
+        session_id = cli.session_commands.current_session_id
+        
+        # Test export
+        session_manager = cli.session_commands.manager
+        json_export = session_manager.export_session(session_id, 'json')
+        md_export = session_manager.export_session(session_id, 'markdown')
+        
+        # Verify content
+        assert 'Test export message' in json_export
+        assert 'Export response' in json_export
+        assert 'Test export message' in md_export
+        assert 'Export response' in md_export
+        
+        # Verify structure
+        assert '"role": "user"' in json_export
+        assert '"role": "assistant"' in json_export
+        assert '👤 User' in md_export or '🤖 Assistant' in md_export
+    
+    def test_conversation_continuity_edge_cases(self, setup_interactive_cli):
+        """Test edge cases in conversation continuity."""
+        cli, mock_provider, db = setup_interactive_cli
+        
+        # Test loading non-existent session
+        result = cli.session_commands.handle_session_command(['load', 'NonExistent'])
+        assert "Session not found" in result
+        
+        # Test saving empty conversation
+        result = cli.session_commands.handle_session_command(['save', 'Empty'])
+        assert "No messages to save" in result
+        
+        # Test clear when already empty
+        cli.session_commands.clear_conversation()
+        was_cleared = cli.session_commands.was_conversation_cleared()
+        assert was_cleared
+        
+        # Test loading when no flag set
+        loaded_messages = cli.session_commands.get_loaded_messages_for_cli()
+        assert len(loaded_messages) == 0

--- a/tests/session/test_manager.py
+++ b/tests/session/test_manager.py
@@ -1,0 +1,353 @@
+"""Tests for session manager functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+import pytest
+
+from coda.session import SessionDatabase, SessionManager
+from coda.session.models import SessionStatus
+
+
+class TestSessionManager:
+    """Test session management operations."""
+    
+    @pytest.fixture
+    def manager(self):
+        """Create a session manager with temporary database."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        
+        db = SessionDatabase(db_path)
+        manager = SessionManager(db)
+        yield manager
+        
+        # Cleanup
+        db.close()
+        db_path.unlink()
+    
+    def test_create_session(self, manager):
+        """Test creating a new session."""
+        session = manager.create_session(
+            name="Test Session",
+            provider="oci_genai",
+            model="cohere.command-r-plus",
+            mode="code",
+            description="Test session for unit tests"
+        )
+        
+        assert session.name == "Test Session"
+        assert session.provider == "oci_genai"
+        assert session.model == "cohere.command-r-plus"
+        assert session.mode == "code"
+        assert session.description == "Test session for unit tests"
+        assert session.status == SessionStatus.ACTIVE.value
+    
+    def test_add_message(self, manager):
+        """Test adding messages to a session."""
+        # Create session
+        session = manager.create_session(
+            name="Message Test",
+            provider="test",
+            model="test-model"
+        )
+        
+        # Add messages
+        msg1 = manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="What is Python?",
+            metadata={"timestamp": "2024-01-01T10:00:00"}
+        )
+        
+        msg2 = manager.add_message(
+            session_id=session.id,
+            role="assistant",
+            content="Python is a high-level programming language.",
+            model="test-model",
+            provider="test",
+            token_usage={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            cost=0.001
+        )
+        
+        # Verify messages
+        assert msg1.sequence == 1
+        assert msg2.sequence == 2
+        assert msg2.total_tokens == 30
+        assert msg2.cost == 0.001
+        
+        # Verify session updated
+        updated_session = manager.get_session(session.id)
+        assert updated_session.message_count == 2
+        assert updated_session.total_tokens == 30
+        assert updated_session.total_cost == 0.001
+    
+    def test_get_messages(self, manager):
+        """Test retrieving messages from a session."""
+        # Create session with messages
+        session = manager.create_session(
+            name="Retrieval Test",
+            provider="test",
+            model="test-model"
+        )
+        
+        for i in range(5):
+            manager.add_message(
+                session_id=session.id,
+                role="user" if i % 2 == 0 else "assistant",
+                content=f"Message {i}"
+            )
+        
+        # Get all messages
+        messages = manager.get_messages(session.id)
+        assert len(messages) == 5
+        assert messages[0].content == "Message 0"
+        assert messages[4].content == "Message 4"
+        
+        # Get limited messages
+        limited = manager.get_messages(session.id, limit=3)
+        assert len(limited) == 3
+        
+        # Get with offset
+        offset_msgs = manager.get_messages(session.id, limit=2, offset=2)
+        assert len(offset_msgs) == 2
+        assert offset_msgs[0].content == "Message 2"
+    
+    def test_search_sessions(self, manager):
+        """Test full-text search across sessions."""
+        # Create sessions with searchable content
+        session1 = manager.create_session(
+            name="Python Tutorial",
+            provider="test",
+            model="test"
+        )
+        manager.add_message(
+            session_id=session1.id,
+            role="user",
+            content="How do I use decorators in Python?"
+        )
+        
+        session2 = manager.create_session(
+            name="JavaScript Guide",
+            provider="test",
+            model="test"
+        )
+        manager.add_message(
+            session_id=session2.id,
+            role="user",
+            content="What are arrow functions in JavaScript?"
+        )
+        
+        # Search for Python
+        results = manager.search_sessions("Python")
+        assert len(results) == 1
+        assert results[0][0].name == "Python Tutorial"
+        
+        # Search for functions
+        results = manager.search_sessions("functions")
+        assert len(results) == 1
+        assert results[0][0].name == "JavaScript Guide"
+    
+    def test_session_branching(self, manager):
+        """Test creating session branches."""
+        # Create parent session with messages
+        parent = manager.create_session(
+            name="Parent Session",
+            provider="test",
+            model="test"
+        )
+        
+        msg1 = manager.add_message(
+            session_id=parent.id,
+            role="user",
+            content="First message"
+        )
+        msg2 = manager.add_message(
+            session_id=parent.id,
+            role="assistant",
+            content="First response"
+        )
+        msg3 = manager.add_message(
+            session_id=parent.id,
+            role="user",
+            content="Second message"
+        )
+        
+        # Create branch from second message
+        branch = manager.create_session(
+            name="Branch Session",
+            provider="test",
+            model="test",
+            parent_id=parent.id,
+            branch_point_message_id=msg2.id
+        )
+        
+        # Verify branch has messages up to branch point
+        branch_messages = manager.get_messages(branch.id)
+        assert len(branch_messages) == 2
+        assert branch_messages[0].content == "First message"
+        assert branch_messages[1].content == "First response"
+    
+    def test_delete_session(self, manager):
+        """Test session deletion."""
+        # Create session
+        session = manager.create_session(
+            name="Delete Test",
+            provider="test",
+            model="test"
+        )
+        session_id = session.id
+        
+        # Soft delete
+        manager.delete_session(session_id, hard_delete=False)
+        deleted = manager.get_session(session_id)
+        assert deleted.status == SessionStatus.DELETED.value
+        
+        # Hard delete
+        manager.delete_session(session_id, hard_delete=True)
+        assert manager.get_session(session_id) is None
+    
+    def test_archive_session(self, manager):
+        """Test session archival."""
+        session = manager.create_session(
+            name="Archive Test",
+            provider="test",
+            model="test"
+        )
+        
+        manager.archive_session(session.id)
+        archived = manager.get_session(session.id)
+        assert archived.status == SessionStatus.ARCHIVED.value
+    
+    def test_update_session(self, manager):
+        """Test updating session metadata."""
+        session = manager.create_session(
+            name="Update Test",
+            provider="test",
+            model="test"
+        )
+        
+        # Update with tags
+        manager.update_session(
+            session.id,
+            name="Updated Name",
+            description="New description",
+            tags=["python", "testing"],
+            config={"theme": "dark"}
+        )
+        
+        updated = manager.get_session(session.id)
+        assert updated.name == "Updated Name"
+        assert updated.description == "New description"
+        assert len(updated.tags) == 2
+        assert {tag.name for tag in updated.tags} == {"python", "testing"}
+        assert updated.config["theme"] == "dark"
+    
+    def test_get_session_context(self, manager):
+        """Test getting session context with windowing."""
+        session = manager.create_session(
+            name="Context Test",
+            provider="test",
+            model="gpt-3.5-turbo"
+        )
+        
+        # Add many messages
+        for i in range(20):
+            manager.add_message(
+                session_id=session.id,
+                role="user" if i % 2 == 0 else "assistant",
+                content=f"Message {i} " * 50  # Make messages longer
+            )
+        
+        # Get context with token limit
+        context, was_truncated = manager.get_session_context(
+            session.id,
+            max_tokens=1000,
+            model="gpt-3.5-turbo"
+        )
+        
+        assert was_truncated
+        assert len(context) < 20  # Should be truncated
+        # Should have summary message
+        assert any(msg['role'] == 'system' and 'summary' in msg['content'].lower() 
+                  for msg in context)
+    
+    def test_export_json(self, manager):
+        """Test exporting session as JSON."""
+        session = manager.create_session(
+            name="Export Test",
+            provider="test",
+            model="test"
+        )
+        
+        manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="Test message"
+        )
+        
+        # Export as JSON
+        json_export = manager.export_session(session.id, format='json')
+        data = json.loads(json_export)
+        
+        assert data['session']['name'] == "Export Test"
+        assert len(data['messages']) == 1
+        assert data['messages'][0]['content'] == "Test message"
+    
+    def test_export_markdown(self, manager):
+        """Test exporting session as Markdown."""
+        session = manager.create_session(
+            name="Markdown Export",
+            provider="test",
+            model="test",
+            description="Test description"
+        )
+        
+        manager.add_message(session_id=session.id, role="user", content="Hello")
+        manager.add_message(session_id=session.id, role="assistant", content="Hi there!")
+        
+        # Export as Markdown
+        md_export = manager.export_session(session.id, format='markdown')
+        
+        assert "# Markdown Export" in md_export
+        assert "Test description" in md_export
+        assert "👤 User" in md_export
+        assert "🤖 Assistant" in md_export
+        assert "Hello" in md_export
+        assert "Hi there!" in md_export
+    
+    def test_export_html(self, manager):
+        """Test exporting session as HTML."""
+        session = manager.create_session(
+            name="HTML Export",
+            provider="test",
+            model="test"
+        )
+        
+        manager.add_message(session_id=session.id, role="user", content="Test")
+        
+        # Export as HTML
+        html_export = manager.export_session(session.id, format='html')
+        
+        assert "<!DOCTYPE html>" in html_export
+        assert "<title>HTML Export</title>" in html_export
+        assert 'class="message user"' in html_export
+        assert "Test" in html_export
+    
+    def test_get_active_sessions(self, manager):
+        """Test retrieving active sessions."""
+        # Create mix of sessions
+        active1 = manager.create_session(name="Active 1", provider="test", model="test")
+        active2 = manager.create_session(name="Active 2", provider="test", model="test")
+        archived = manager.create_session(name="Archived", provider="test", model="test")
+        
+        manager.archive_session(archived.id)
+        
+        # Get active sessions
+        active_sessions = manager.get_active_sessions()
+        assert len(active_sessions) == 2
+        assert {s.name for s in active_sessions} == {"Active 1", "Active 2"}
+        
+        # Test pagination
+        page1 = manager.get_active_sessions(limit=1, offset=0)
+        assert len(page1) == 1

--- a/tests/unit/test_command_registry.py
+++ b/tests/unit/test_command_registry.py
@@ -1,0 +1,112 @@
+"""Test command registry functionality."""
+
+import pytest
+from coda.cli.command_registry import CommandRegistry, CommandDefinition, CommandType
+
+
+class TestCommandRegistry:
+    """Test the centralized command registry."""
+    
+    def test_session_subcommands_defined(self):
+        """Test that all session subcommands are defined."""
+        expected_subcommands = {
+            'save', 'load', 'last', 'list', 'branch', 
+            'delete', 'delete-all', 'rename', 'info', 'search'
+        }
+        
+        actual_subcommands = {cmd.name for cmd in CommandRegistry.SESSION_SUBCOMMANDS}
+        assert actual_subcommands == expected_subcommands
+    
+    def test_get_command(self):
+        """Test getting command by name."""
+        session_cmd = CommandRegistry.get_command("session")
+        assert session_cmd is not None
+        assert session_cmd.name == "session"
+        assert "s" in session_cmd.aliases
+    
+    def test_get_command_by_alias(self):
+        """Test getting command by alias."""
+        session_cmd = CommandRegistry.get_command("s")
+        assert session_cmd is not None
+        assert session_cmd.name == "session"
+    
+    def test_get_subcommand(self):
+        """Test getting subcommand."""
+        session_cmd = CommandRegistry.get_command("session")
+        save_cmd = session_cmd.get_subcommand("save")
+        assert save_cmd is not None
+        assert save_cmd.name == "save"
+        assert save_cmd.type == CommandType.SUBCOMMAND
+    
+    def test_get_subcommand_by_alias(self):
+        """Test getting subcommand by alias."""
+        session_cmd = CommandRegistry.get_command("session")
+        save_cmd = session_cmd.get_subcommand("s")  # alias for save
+        assert save_cmd is not None
+        assert save_cmd.name == "save"
+    
+    def test_autocomplete_options(self):
+        """Test getting autocomplete options."""
+        options = CommandRegistry.get_autocomplete_options()
+        
+        # Check session options
+        assert "session" in options
+        session_options = options["session"]
+        
+        # Should be list of tuples
+        assert isinstance(session_options, list)
+        assert all(isinstance(opt, tuple) and len(opt) == 2 for opt in session_options)
+        
+        # Check specific commands
+        option_names = [opt[0] for opt in session_options]
+        assert "last" in option_names
+        assert "rename" in option_names
+        assert "delete-all" in option_names
+    
+    def test_command_help(self):
+        """Test command help generation."""
+        help_text = CommandRegistry.get_command_help("session")
+        
+        # Should contain command name and description
+        assert "session" in help_text
+        assert "Manage sessions" in help_text
+        
+        # Should list subcommands
+        assert "save" in help_text
+        assert "load" in help_text
+        assert "last" in help_text
+        assert "rename" in help_text
+        assert "delete-all" in help_text
+        
+        # Should show aliases
+        assert "aliases: s" in help_text
+    
+    def test_command_help_all(self):
+        """Test getting help for all commands."""
+        help_text = CommandRegistry.get_command_help()
+        
+        # Should list main commands
+        assert "/session" in help_text
+        assert "/help" in help_text
+        assert "/exit" in help_text
+        assert "/model" in help_text
+    
+    def test_examples_included(self):
+        """Test that examples are included in definitions."""
+        session_cmd = CommandRegistry.get_command("session")
+        last_cmd = session_cmd.get_subcommand("last")
+        
+        assert len(last_cmd.examples) > 0
+        assert "/session last" in last_cmd.examples
+    
+    def test_new_commands_have_all_fields(self):
+        """Test that new commands have all required fields."""
+        new_commands = ["last", "rename", "delete-all"]
+        
+        session_cmd = CommandRegistry.get_command("session")
+        for cmd_name in new_commands:
+            cmd = session_cmd.get_subcommand(cmd_name)
+            assert cmd is not None
+            assert cmd.name == cmd_name
+            assert cmd.description
+            assert cmd.type == CommandType.SUBCOMMAND

--- a/tests/unit/test_session_autosave.py
+++ b/tests/unit/test_session_autosave.py
@@ -1,0 +1,279 @@
+"""Unit tests for session auto-save functionality."""
+
+import tempfile
+from pathlib import Path
+import pytest
+from unittest.mock import Mock, patch
+
+from coda.session import SessionDatabase, SessionManager, SessionCommands
+from coda.session.models import Session
+
+
+class TestSessionAutoSave:
+    """Test auto-save functionality for sessions."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    @pytest.fixture
+    def session_manager(self, temp_db_path):
+        """Create session manager with temporary database."""
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        yield manager
+        db.close()
+    
+    @pytest.fixture
+    def session_commands(self, session_manager):
+        """Create session commands instance."""
+        return SessionCommands(session_manager)
+    
+    def test_auto_save_enabled_by_default(self, session_commands):
+        """Test that auto-save is enabled by default."""
+        assert session_commands.auto_save_enabled is True
+    
+    def test_auto_save_disabled_when_configured(self, session_manager):
+        """Test that auto-save can be disabled."""
+        commands = SessionCommands(session_manager)
+        commands.auto_save_enabled = False
+        assert commands.auto_save_enabled is False
+    
+    def test_no_auto_save_without_user_message(self, session_commands):
+        """Test that auto-save doesn't trigger without user message."""
+        # Add only assistant message
+        session_commands.add_message(
+            role="assistant",
+            content="Hello there!",
+            metadata={"provider": "test", "model": "test-model"}
+        )
+        
+        # Should not create a session
+        assert session_commands.current_session_id is None
+        assert len(session_commands.current_messages) == 1
+    
+    def test_auto_save_on_first_exchange(self, session_commands):
+        """Test that auto-save triggers on first user-assistant exchange."""
+        # Add user message
+        session_commands.add_message(
+            role="user",
+            content="Hello AI!",
+            metadata={"mode": "general"}
+        )
+        
+        # Session should not be created yet
+        assert session_commands.current_session_id is None
+        
+        # Add assistant response
+        session_commands.add_message(
+            role="assistant",
+            content="Hello! How can I help you?",
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        # Session should now be created
+        assert session_commands.current_session_id is not None
+        assert len(session_commands.current_messages) == 2
+        
+        # Verify session in database
+        session = session_commands.manager.get_session(session_commands.current_session_id)
+        assert session is not None
+        assert session.name.startswith("auto-")
+        assert session.description == "Auto-saved conversation"
+        assert session.provider == "mock"
+        assert session.model == "mock-echo"
+        assert session.mode == "general"
+        
+        # Verify messages were saved
+        messages = session_commands.manager.get_messages(session.id)
+        assert len(messages) == 2
+        assert messages[0].role == "user"
+        assert messages[0].content == "Hello AI!"
+        assert messages[1].role == "assistant"
+        assert messages[1].content == "Hello! How can I help you?"
+    
+    def test_no_auto_save_when_disabled(self, session_commands):
+        """Test that auto-save doesn't trigger when disabled."""
+        # Disable auto-save
+        session_commands.auto_save_enabled = False
+        
+        # Add user message
+        session_commands.add_message(
+            role="user",
+            content="Hello AI!",
+            metadata={"mode": "general"}
+        )
+        
+        # Add assistant response
+        session_commands.add_message(
+            role="assistant",
+            content="Hello! How can I help you?",
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        # Session should not be created
+        assert session_commands.current_session_id is None
+        assert len(session_commands.current_messages) == 2
+    
+    def test_subsequent_messages_saved_to_existing_session(self, session_commands):
+        """Test that subsequent messages are saved to existing auto-saved session."""
+        # Create initial exchange to trigger auto-save
+        session_commands.add_message(
+            role="user",
+            content="First message",
+            metadata={"mode": "general"}
+        )
+        session_commands.add_message(
+            role="assistant",
+            content="First response",
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        # Capture session ID
+        session_id = session_commands.current_session_id
+        assert session_id is not None
+        
+        # Add more messages
+        session_commands.add_message(
+            role="user",
+            content="Second message",
+            metadata={"mode": "general"}
+        )
+        session_commands.add_message(
+            role="assistant",
+            content="Second response",
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        # Should still be the same session
+        assert session_commands.current_session_id == session_id
+        
+        # Verify all messages were saved
+        messages = session_commands.manager.get_messages(session_id)
+        assert len(messages) == 4
+        assert messages[2].content == "Second message"
+        assert messages[3].content == "Second response"
+    
+    def test_rename_auto_saved_session(self, session_commands):
+        """Test renaming an auto-saved session."""
+        # Create auto-saved session
+        session_commands.add_message(
+            role="user",
+            content="Test message",
+            metadata={"mode": "general"}
+        )
+        session_commands.add_message(
+            role="assistant",
+            content="Test response",
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        session_id = session_commands.current_session_id
+        assert session_id is not None
+        
+        # Rename the session
+        result = session_commands._rename_session(["My Important Chat"])
+        assert result == "Session renamed to: My Important Chat"
+        
+        # Verify the rename
+        session = session_commands.manager.get_session(session_id)
+        assert session.name == "My Important Chat"
+    
+    @patch('coda.session.commands.Console')
+    def test_auto_save_notification(self, mock_console, session_manager):
+        """Test that auto-save shows notification."""
+        # Create commands with mocked console
+        commands = SessionCommands(session_manager)
+        commands.console = mock_console()
+        
+        # Trigger auto-save
+        commands.add_message(
+            role="user",
+            content="Test",
+            metadata={"mode": "general"}
+        )
+        commands.add_message(
+            role="assistant",
+            content="Response",
+            metadata={
+                "provider": "mock",
+                "model": "mock-echo",
+                "mode": "general"
+            }
+        )
+        
+        # Verify notification was printed
+        commands.console.print.assert_called()
+        calls = commands.console.print.call_args_list
+        # Find the auto-save notification
+        found_notification = False
+        for call in calls:
+            if call[0] and "Auto-saved session:" in str(call[0][0]):
+                found_notification = True
+                break
+        assert found_notification
+    
+    @patch('coda.session.commands.Console')
+    def test_auto_save_error_handling(self, mock_console, session_manager):
+        """Test that auto-save handles errors gracefully."""
+        # Create commands with mocked console
+        commands = SessionCommands(session_manager)
+        commands.console = mock_console()
+        
+        # Mock the create_session to raise an error
+        with patch.object(commands.manager, 'create_session', side_effect=Exception("DB Error")):
+            # Trigger auto-save
+            commands.add_message(
+                role="user",
+                content="Test",
+                metadata={"mode": "general"}
+            )
+            commands.add_message(
+                role="assistant",
+                content="Response",
+                metadata={
+                    "provider": "mock",
+                    "model": "mock-echo",
+                    "mode": "general"
+                }
+            )
+        
+        # Verify error was handled
+        assert commands.current_session_id is None  # No session created
+        assert len(commands.current_messages) == 2  # Messages still tracked
+        
+        # Verify error notification was printed
+        commands.console.print.assert_called()
+        calls = commands.console.print.call_args_list
+        # Find the error notification
+        found_error = False
+        for call in calls:
+            if call[0] and "Auto-save failed:" in str(call[0][0]):
+                found_error = True
+                break
+        assert found_error

--- a/tests/unit/test_session_bulk_delete_and_first_run.py
+++ b/tests/unit/test_session_bulk_delete_and_first_run.py
@@ -1,0 +1,255 @@
+"""Unit tests for Phase 4.5 lower-priority features."""
+
+import tempfile
+from pathlib import Path
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+import os
+
+from coda.session import SessionDatabase, SessionManager, SessionCommands
+from coda.cli.interactive import _check_first_run
+from rich.console import Console
+
+
+class TestBulkDelete:
+    """Test bulk delete functionality."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    @pytest.fixture
+    def session_manager(self, temp_db_path):
+        """Create session manager with temporary database."""
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        yield manager
+        db.close()
+    
+    @pytest.fixture
+    def session_commands(self, session_manager):
+        """Create session commands instance."""
+        return SessionCommands(session_manager)
+    
+    def test_delete_all_with_no_sessions(self, session_commands):
+        """Test delete-all when no sessions exist."""
+        result = session_commands._delete_all_sessions([])
+        assert result == "No sessions found to delete."
+    
+    def test_delete_all_auto_only_with_no_auto_sessions(self, session_commands):
+        """Test delete-all auto-only when no auto sessions exist."""
+        # Create a non-auto session
+        session_commands.manager.create_session(
+            name="Manual Session",
+            provider="mock",
+            model="mock-echo"
+        )
+        
+        result = session_commands._delete_all_sessions(["--auto-only"])
+        assert result == "No auto-saved sessions found to delete."
+    
+    @patch('coda.session.commands.Confirm.ask')
+    def test_delete_all_cancelled(self, mock_confirm, session_commands):
+        """Test delete-all cancelled by user."""
+        # Create sessions
+        for i in range(3):
+            session_commands.manager.create_session(
+                name=f"Session {i}",
+                provider="mock",
+                model="mock-echo"
+            )
+        
+        # User cancels
+        mock_confirm.return_value = False
+        
+        result = session_commands._delete_all_sessions([])
+        assert result == "Deletion cancelled."
+        
+        # Verify sessions still exist
+        sessions = session_commands.manager.get_active_sessions(limit=10)
+        assert len(sessions) == 3
+    
+    @patch('coda.session.commands.Confirm.ask')
+    def test_delete_all_success(self, mock_confirm, session_commands):
+        """Test successful delete-all."""
+        # Create sessions
+        for i in range(3):
+            session_commands.manager.create_session(
+                name=f"Session {i}",
+                provider="mock",
+                model="mock-echo"
+            )
+        
+        # User confirms
+        mock_confirm.return_value = True
+        
+        result = session_commands._delete_all_sessions([])
+        assert result == "Successfully deleted 3 all session(s)."
+        
+        # Verify sessions deleted
+        sessions = session_commands.manager.get_active_sessions(limit=10)
+        assert len(sessions) == 0
+    
+    @patch('coda.session.commands.Confirm.ask')
+    def test_delete_all_auto_only(self, mock_confirm, session_commands):
+        """Test delete-all with auto-only flag."""
+        # Create mixed sessions
+        auto1 = session_commands.manager.create_session(
+            name="auto-20250105_120000",
+            provider="mock",
+            model="mock-echo"
+        )
+        auto2 = session_commands.manager.create_session(
+            name="auto-20250105_130000",
+            provider="mock",
+            model="mock-echo"
+        )
+        manual = session_commands.manager.create_session(
+            name="Manual Session",
+            provider="mock",
+            model="mock-echo"
+        )
+        
+        # User confirms
+        mock_confirm.return_value = True
+        
+        result = session_commands._delete_all_sessions(["--auto-only"])
+        assert result == "Successfully deleted 2 auto-saved session(s)."
+        
+        # Verify only auto sessions deleted
+        sessions = session_commands.manager.get_active_sessions(limit=10)
+        assert len(sessions) == 1
+        assert sessions[0].name == "Manual Session"
+    
+    @patch('coda.session.commands.Confirm.ask')
+    def test_delete_all_clears_current_session(self, mock_confirm, session_commands):
+        """Test that delete-all clears current session if it's being deleted."""
+        # Create and set current session
+        session = session_commands.manager.create_session(
+            name="Current Session",
+            provider="mock",
+            model="mock-echo"
+        )
+        session_commands.current_session_id = session.id
+        session_commands.current_messages = [{"role": "user", "content": "test"}]
+        session_commands._has_user_message = True
+        
+        # User confirms
+        mock_confirm.return_value = True
+        
+        result = session_commands._delete_all_sessions([])
+        
+        # Verify current session cleared
+        assert session_commands.current_session_id is None
+        assert session_commands.current_messages == []
+        assert session_commands._has_user_message is False
+
+
+class TestFirstRunNotification:
+    """Test first-run notification functionality."""
+    
+    @pytest.fixture
+    def temp_home(self, tmp_path):
+        """Create temporary home directory."""
+        home = tmp_path / "home"
+        home.mkdir()
+        with patch.dict(os.environ, {'HOME': str(home)}):
+            yield home
+    
+    @pytest.mark.asyncio
+    async def test_first_run_shows_notification(self, temp_home):
+        """Test that first run shows notification."""
+        console = Console(file=MagicMock())
+        
+        # Ensure marker doesn't exist
+        marker = temp_home / ".local/share/coda/.first_run_complete"
+        assert not marker.exists()
+        
+        # Run first-run check with auto-save enabled
+        await _check_first_run(console, auto_save_enabled=True)
+        
+        # Verify notification was printed
+        console.file.write.assert_called()
+        output = ''.join(call[0][0] for call in console.file.write.call_args_list)
+        assert "Welcome to Coda!" in output
+        assert "Auto-Save is ENABLED" in output
+        assert "💾" in output
+        
+        # Verify marker was created
+        assert marker.exists()
+    
+    @pytest.mark.asyncio
+    async def test_first_run_disabled_notification(self, temp_home):
+        """Test first run with auto-save disabled."""
+        console = Console(file=MagicMock())
+        
+        # Run first-run check with auto-save disabled
+        await _check_first_run(console, auto_save_enabled=False)
+        
+        # Verify correct notification
+        output = ''.join(call[0][0] for call in console.file.write.call_args_list)
+        assert "Welcome to Coda!" in output
+        assert "Auto-Save is DISABLED" in output
+        assert "🔒" in output
+    
+    @pytest.mark.asyncio
+    async def test_subsequent_run_no_notification(self, temp_home):
+        """Test that subsequent runs don't show notification."""
+        console = Console(file=MagicMock())
+        
+        # Create marker manually
+        marker = temp_home / ".local/share/coda/.first_run_complete"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+        
+        # Run first-run check
+        await _check_first_run(console, auto_save_enabled=True)
+        
+        # Verify no notification
+        console.file.write.assert_not_called()
+
+
+class TestDatabaseIndexes:
+    """Test that database indexes are created properly."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    def test_indexes_created(self, temp_db_path):
+        """Test that all indexes are created in the database."""
+        # Create database
+        db = SessionDatabase(temp_db_path)
+        
+        # Get connection to check indexes
+        conn = db.engine.connect()
+        
+        # Query for indexes
+        from sqlalchemy import text
+        result = conn.execute(text("SELECT name FROM sqlite_master WHERE type='index' AND sql NOT NULL"))
+        index_names = [row[0] for row in result]
+        
+        # Verify new indexes exist
+        expected_indexes = [
+            'idx_session_created',
+            'idx_session_accessed',
+            'idx_session_name',
+            'idx_session_parent',
+            'idx_session_tags_tag'
+        ]
+        
+        for expected in expected_indexes:
+            assert any(expected in idx for idx in index_names), f"Index {expected} not found"
+        
+        conn.close()
+        db.close()

--- a/tests/unit/test_session_last.py
+++ b/tests/unit/test_session_last.py
@@ -1,0 +1,226 @@
+"""Unit tests for 'load last session' functionality."""
+
+import tempfile
+from pathlib import Path
+from datetime import datetime, timedelta
+import pytest
+from unittest.mock import Mock, patch
+
+from coda.session import SessionDatabase, SessionManager, SessionCommands
+from coda.session.models import Session
+
+
+class TestSessionLast:
+    """Test load last session functionality."""
+    
+    @pytest.fixture
+    def temp_db_path(self):
+        """Create temporary database path."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = Path(f.name)
+        yield db_path
+        if db_path.exists():
+            db_path.unlink()
+    
+    @pytest.fixture
+    def session_manager(self, temp_db_path):
+        """Create session manager with temporary database."""
+        db = SessionDatabase(temp_db_path)
+        manager = SessionManager(db)
+        yield manager
+        db.close()
+    
+    @pytest.fixture
+    def session_commands(self, session_manager):
+        """Create session commands instance."""
+        return SessionCommands(session_manager)
+    
+    def test_load_last_with_no_sessions(self, session_commands):
+        """Test loading last session when no sessions exist."""
+        result = session_commands._load_last_session()
+        assert result == "No sessions found to load."
+    
+    def test_load_last_with_single_session(self, session_commands):
+        """Test loading last session with one session."""
+        # Create a session
+        session = session_commands.manager.create_session(
+            name="Test Session",
+            description="Test description",
+            provider="mock",
+            model="mock-echo",
+            mode="general"
+        )
+        
+        # Add some messages
+        session_commands.manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="Hello",
+            metadata={}
+        )
+        session_commands.manager.add_message(
+            session_id=session.id,
+            role="assistant",
+            content="Hi there!",
+            metadata={}
+        )
+        
+        # Load last session
+        result = session_commands._load_last_session()
+        assert result is None  # Success
+        
+        # Verify session loaded
+        assert session_commands.current_session_id == session.id
+        assert len(session_commands.current_messages) == 2
+        assert session_commands.current_messages[0]['content'] == "Hello"
+        assert session_commands.current_messages[1]['content'] == "Hi there!"
+        assert session_commands._messages_loaded is True
+    
+    def test_load_last_with_multiple_sessions(self, session_commands):
+        """Test loading last session returns most recent."""
+        # Create older session
+        older = session_commands.manager.create_session(
+            name="Older Session",
+            provider="mock",
+            model="mock-echo",
+            mode="general"
+        )
+        
+        # Add a message to older session
+        session_commands.manager.add_message(
+            session_id=older.id,
+            role="user",
+            content="Old message",
+            metadata={}
+        )
+        
+        # Create newer session (will have later created_at)
+        import time
+        time.sleep(0.1)  # Ensure different timestamp
+        
+        newer = session_commands.manager.create_session(
+            name="Newer Session",
+            provider="mock",
+            model="mock-smart",
+            mode="code"
+        )
+        
+        # Add messages to newer session
+        session_commands.manager.add_message(
+            session_id=newer.id,
+            role="user",
+            content="New message",
+            metadata={}
+        )
+        session_commands.manager.add_message(
+            session_id=newer.id,
+            role="assistant",
+            content="New response",
+            metadata={}
+        )
+        
+        # Load last session
+        result = session_commands._load_last_session()
+        assert result is None  # Success
+        
+        # Should load the newer session
+        assert session_commands.current_session_id == newer.id
+        assert len(session_commands.current_messages) == 2
+        assert session_commands.current_messages[0]['content'] == "New message"
+    
+    def test_load_last_preserves_metadata(self, session_commands):
+        """Test that load last preserves message metadata."""
+        # Create session
+        session = session_commands.manager.create_session(
+            name="Metadata Test",
+            provider="ollama",
+            model="llama3",
+            mode="debug"
+        )
+        
+        # Add message with metadata
+        session_commands.manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="Test",
+            metadata={"custom": "data"},
+            model="llama3",
+            provider="ollama",
+            token_usage={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            cost=0.001
+        )
+        
+        # Load last session
+        session_commands._load_last_session()
+        
+        # Check metadata preserved
+        msg = session_commands.current_messages[0]
+        assert msg['metadata']['provider'] == "ollama"
+        assert msg['metadata']['model'] == "llama3"
+        assert msg['metadata']['mode'] == "debug"
+        assert msg['metadata']['token_usage']['total_tokens'] == 30
+        assert msg['metadata']['cost'] == 0.001
+    
+    @patch('coda.session.commands.Console')
+    def test_load_last_displays_session_info(self, mock_console, session_manager):
+        """Test that load last displays session information."""
+        # Create commands with mocked console
+        commands = SessionCommands(session_manager)
+        commands.console = mock_console()
+        
+        # Create session with description
+        session = commands.manager.create_session(
+            name="Display Test",
+            description="This is a test session",
+            provider="litellm",
+            model="gpt-4",
+            mode="explain"
+        )
+        
+        # Add a message
+        commands.manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="Test",
+            metadata={}
+        )
+        
+        # Load last session
+        commands._load_last_session()
+        
+        # Verify console output
+        calls = commands.console.print.call_args_list
+        
+        # Should display session name
+        assert any("Display Test" in str(call[0][0]) for call in calls)
+        
+        # Should display provider and model
+        assert any("litellm" in str(call[0][0]) and "gpt-4" in str(call[0][0]) for call in calls)
+        
+        # Should display description
+        assert any("This is a test session" in str(call[0][0]) for call in calls)
+    
+    def test_session_last_command_integration(self, session_commands):
+        """Test /session last command through handle_session_command."""
+        # Create a session
+        session = session_commands.manager.create_session(
+            name="Command Test",
+            provider="mock",
+            model="mock-echo",
+            mode="general"
+        )
+        
+        # Add message
+        session_commands.manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="Test command",
+            metadata={}
+        )
+        
+        # Call through command handler
+        result = session_commands.handle_session_command(['last'])
+        
+        # Should succeed
+        assert result is None
+        assert session_commands.current_session_id == session.id

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sqlalchemy" },
+    { name = "tiktoken" },
     { name = "tomlkit" },
 ]
 
@@ -335,6 +336,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "tomlkit", specifier = ">=0.12.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

This PR completes **Phase 4: Session Management** along with the enhanced CLI experience features from Phase 3. All functionality is fully implemented and tested.

### Key Features Implemented

**Session Infrastructure:**
- ✅ SQLAlchemy-based session database with automatic migrations
- ✅ Full session management system (create, save, load, branch, delete)
- ✅ Message persistence with provider/model metadata tracking
- ✅ Full-text search across all sessions using SQLite FTS5
- ✅ Session branching for exploring alternate conversation paths
- ✅ Export functionality (JSON, Markdown, TXT, HTML)

**CLI Enhancements:**
- ✅ Auto-save functionality with anonymous sessions
- ✅ `/session` command with 9 subcommands (save, load, last, list, branch, delete, delete-all, rename, info, search)
- ✅ `/export` command with 4 formats
- ✅ `--resume` flag for auto-loading last session
- ✅ Command registry for consistent autocomplete and help
- ✅ Dynamic context limits from provider models

**MockProvider for Testing:**
- ✅ Deterministic mock provider for offline testing
- ✅ Context-aware responses for testing conversation flows
- ✅ Two models: mock-echo (4K) and mock-smart (8K)

## Test Results

```
========== 323 passed, 26 skipped, 0 failed ==========
```

All tests are passing! This includes:
- 51 tests for MockProvider conversations
- Tests for all 7 developer modes
- Tests for all CLI commands
- End-to-end session workflow tests
- Edge case and error handling coverage

## Code Quality Analysis

A comprehensive analysis of the codebase revealed opportunities for refactoring, which have been documented in **Phase 4.6: Code Quality Refactoring** in the roadmap. Key findings:

**Hardcoded Values:**
- Path constants scattered throughout (`.coda`, `.config`, `sessions.db`)
- Query limits (50, 100, 1000) hardcoded in multiple places
- UI colors and styles embedded in CLI modules
- Cache durations and default parameters

**Code Structure:**
- Duplicate command definitions (CommandRegistry + unused YAML)
- Overlapping functionality between `interactive.py` and `interactive_cli.py`
- Unnecessary wrapper methods that could call shared functions directly

## Merge Strategy

**Plan: Option 1 - Merge First, Refactor Second** ✅

1. **Merge this PR** to main (current functionality is stable and well-tested)
2. **Create new branch** `feature/code-quality-refactor` from main
3. **Implement Phase 4.6** refactoring tasks
4. **Then proceed** with Phase 5: Tool Integration (MCP)

This approach:
- Keeps PRs focused and manageable
- Allows the stable session management features to be released
- Provides a clean base for refactoring work
- Prevents blocking Phase 5 development

## AI Development Summary

**AI Prompt**: "see agents.md and roadmap.md. we're about to merge our pr. Let's take a step back and analyze all of the changes in this branch since main. Let's see if we need to refactor or modularize anything before we file our merge request. We especially want to avoid hardcoding things wherever possible"

**AI Tools Used**: Task, Bash, Grep, Read, Edit, MultiEdit, Write, TodoWrite

**Key Technical Changes:**
1. Fixed 21 failing session-related tests
2. Resolved SQLAlchemy detached instance errors  
3. Fixed context manager model limits
4. Created provider utilities to eliminate code duplication
5. Improved test robustness with comprehensive mocking
6. Centralized command autocomplete in CommandRegistry
7. Implemented dynamic context limits from provider models

## Breaking Changes

None - all changes are backward compatible.

## Checklist

- [x] All tests pass
- [x] Code follows project conventions
- [x] Conventional commits used
- [x] No PII in commit messages
- [x] Ready for automated release
- [x] Refactoring needs documented in roadmap

## Next Steps

1. Merge this PR to release Phase 4 functionality
2. Create `feature/code-quality-refactor` branch for Phase 4.6
3. Complete refactoring tasks (constants.py, consolidate CLI modules, etc.)
4. Begin Phase 5: Tool Integration (MCP)