### PR TITLE
feat(session): implement Phase 4.5 - Tool Integration with Sessions

### DIFF
--- a/coda/cli/interactive.py
+++ b/coda/cli/interactive.py
@@ -283,6 +283,28 @@ async def _handle_chat_interaction(
                 # Update messages to match what happened
                 messages.clear()
                 messages.extend(updated_messages)
+
+                # Save all messages from the agent interaction to session
+                from ..session.tool_storage import format_tool_calls_for_storage
+
+                # Find and save new messages (after the user message which was already saved)
+                # Skip the first message (user) since it was already saved above
+                for msg in updated_messages[1:]:
+                    tool_calls_data = None
+                    if hasattr(msg, 'tool_calls') and msg.tool_calls:
+                        tool_calls_data = format_tool_calls_for_storage(msg.tool_calls)
+
+                    cli.session_commands.add_message(
+                        role=msg.role.value if hasattr(msg.role, 'value') else str(msg.role),
+                        content=msg.content,
+                        tool_calls=tool_calls_data,
+                        metadata={
+                            "mode": cli.current_mode.value,
+                            "provider": provider_instance.name if hasattr(provider_instance, "name") else "unknown",
+                            "model": cli.current_model,
+                            "tool_call_id": getattr(msg, 'tool_call_id', None),
+                        },
+                    )
         else:
             # Use regular streaming
             with console.status(

--- a/coda/session/tool_storage.py
+++ b/coda/session/tool_storage.py
@@ -1,0 +1,66 @@
+"""Tool call storage utilities for session management."""
+
+from typing import Any
+
+
+def format_tool_calls_for_storage(tool_calls: list[Any]) -> list[dict]:
+    """Format tool calls for database storage.
+
+    Args:
+        tool_calls: List of tool call objects from provider
+
+    Returns:
+        List of dictionaries suitable for JSON storage
+    """
+    if not tool_calls:
+        return []
+
+    formatted_calls = []
+    for call in tool_calls:
+        # Handle different tool call formats
+        if hasattr(call, "__dict__"):
+            # Object with attributes
+            formatted_call = {
+                "id": getattr(call, "id", None),
+                "name": getattr(call, "name", None),
+                "arguments": getattr(call, "arguments", {}),
+            }
+        elif isinstance(call, dict):
+            # Already a dictionary
+            formatted_call = {
+                "id": call.get("id"),
+                "name": call.get("name"),
+                "arguments": call.get("arguments", {}),
+            }
+        else:
+            # Unknown format, store as string
+            formatted_call = {"raw": str(call)}
+
+        formatted_calls.append(formatted_call)
+
+    return formatted_calls
+
+
+def format_tool_result_for_storage(tool_result: Any) -> dict:
+    """Format a tool execution result for storage.
+
+    Args:
+        tool_result: Tool execution result
+
+    Returns:
+        Dictionary suitable for JSON storage
+    """
+    if hasattr(tool_result, "__dict__"):
+        return {
+            "tool_call_id": getattr(tool_result, "tool_call_id", None),
+            "content": getattr(tool_result, "content", str(tool_result)),
+            "is_error": getattr(tool_result, "is_error", False),
+        }
+    elif isinstance(tool_result, dict):
+        return {
+            "tool_call_id": tool_result.get("tool_call_id"),
+            "content": tool_result.get("content", str(tool_result)),
+            "is_error": tool_result.get("is_error", False),
+        }
+    else:
+        return {"content": str(tool_result)}

--- a/scripts/test_tool_storage.py
+++ b/scripts/test_tool_storage.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Manual test script for tool storage functionality."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from coda.session.commands import SessionCommands
+from coda.session.database import SessionDatabase
+from coda.session.manager import SessionManager
+from coda.session.tool_storage import format_tool_calls_for_storage
+
+
+async def test_tool_storage():
+    """Test tool storage end-to-end."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create database
+        db_path = Path(tmpdir) / "test_tools.db"
+        db = SessionDatabase(db_path)
+        manager = SessionManager(db)
+        commands = SessionCommands(manager)
+
+        print("✓ Created database and manager")
+
+        # Create a session
+        session = manager.create_session(
+            name="Manual Tool Test",
+            provider="cohere",
+            model="cohere.command-r-plus",
+            mode="code"
+        )
+        commands.current_session_id = session.id
+
+        print(f"✓ Created session: {session.name} (ID: {session.id[:8]}...)")
+
+        # Simulate tool calls
+        tool_calls = [
+            {"id": "call_001", "name": "read_file", "arguments": {"path": "/src/main.py"}},
+            {"id": "call_002", "name": "list_directory", "arguments": {"path": "/src"}},
+        ]
+
+        # Add assistant message with tool calls
+        formatted_calls = format_tool_calls_for_storage(tool_calls)
+        manager.add_message(
+            session.id,
+            "assistant",
+            "I'll examine your source files.",
+            tool_calls=formatted_calls,
+            model="cohere.command-r-plus",
+            provider="cohere"
+        )
+
+        print("✓ Added assistant message with 2 tool calls")
+
+        # Add tool results
+        manager.add_message(
+            session.id,
+            "tool",
+            "# main.py\n\ndef main():\n    print('Hello, World!')",
+            metadata={"tool_call_id": "call_001"}
+        )
+
+        manager.add_message(
+            session.id,
+            "tool",
+            "Files: main.py, utils.py, test_main.py",
+            metadata={"tool_call_id": "call_002"}
+        )
+
+        print("✓ Added tool results")
+
+        # Add another round of tool usage
+        tool_calls2 = [
+            {"id": "call_003", "name": "write_file", "arguments": {"path": "/src/utils.py", "content": "# utils"}},
+        ]
+
+        manager.add_message(
+            session.id,
+            "assistant",
+            "I'll create a utils module.",
+            tool_calls=format_tool_calls_for_storage(tool_calls2)
+        )
+
+        manager.add_message(
+            session.id,
+            "tool",
+            "File written successfully",
+            metadata={"tool_call_id": "call_003"}
+        )
+
+        print("✓ Added second round of tool usage")
+
+        # Test retrieval
+        history = manager.get_tool_history(session.id)
+        print(f"\n✓ Tool history: {len(history)} entries")
+
+        # Test summary
+        summary = manager.get_session_tools_summary(session.id)
+        print("\n✓ Tool Summary:")
+        print(f"  - Total calls: {summary['total_tool_calls']}")
+        print(f"  - Unique tools: {summary['unique_tools']}")
+        print(f"  - Most used: {summary['most_used']}")
+        print(f"  - Counts: {summary['tool_counts']}")
+
+        # Test the command
+        print("\n✓ Running /session tools command:")
+        print("-" * 50)
+        result = commands.handle_session_command(["tools"])
+        if result:
+            print(f"Command returned: {result}")
+        print("-" * 50)
+
+        # Verify data integrity
+        messages = manager.get_messages(session.id)
+        tool_messages = [m for m in messages if m.tool_calls]
+        print(f"\n✓ Found {len(tool_messages)} messages with tool calls")
+
+        for i, msg in enumerate(tool_messages, 1):
+            print(f"  Message {i}: {len(msg.tool_calls)} tool calls")
+            for call in msg.tool_calls:
+                print(f"    - {call['name']} (ID: {call['id']})")
+
+        print("\n✅ All tests passed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_tool_storage())
+

--- a/tests/integration/test_tool_storage_simple.py
+++ b/tests/integration/test_tool_storage_simple.py
@@ -1,0 +1,177 @@
+"""Simple integration test for tool call storage."""
+
+
+import pytest
+
+from coda.session.database import SessionDatabase
+from coda.session.manager import SessionManager
+from coda.session.tool_storage import format_tool_calls_for_storage
+
+
+class TestToolStorageSimple:
+    """Simple test for tool storage functionality."""
+
+    @pytest.mark.integration
+    def test_tool_storage_basic_flow(self, tmp_path):
+        """Test basic tool storage flow."""
+        # Create database and manager
+        db_path = tmp_path / "test_tools.db"
+        db = SessionDatabase(db_path)
+        manager = SessionManager(db)
+
+        # Create a session
+        session = manager.create_session(
+            name="Tool Test",
+            provider="test",
+            model="test-model",
+            mode="code"
+        )
+
+        # Add a message with tool calls
+        tool_calls = [
+            {"id": "tc1", "name": "read_file", "arguments": {"path": "test.py"}},
+            {"id": "tc2", "name": "write_file", "arguments": {"path": "out.txt", "content": "test"}}
+        ]
+
+        # Format tool calls for storage
+        formatted_calls = format_tool_calls_for_storage(tool_calls)
+
+        # Add message with tool calls
+        manager.add_message(
+            session_id=session.id,
+            role="assistant",
+            content="I'll help you with those files.",
+            tool_calls=formatted_calls
+        )
+
+        # Add tool results
+        manager.add_message(
+            session_id=session.id,
+            role="tool",
+            content="File content: print('hello')",
+            metadata={"tool_call_id": "tc1"}
+        )
+
+        manager.add_message(
+            session_id=session.id,
+            role="tool",
+            content="File written successfully",
+            metadata={"tool_call_id": "tc2"}
+        )
+
+        # Test retrieval
+        tool_history = manager.get_tool_history(session.id)
+        assert len(tool_history) == 3  # 1 call message + 2 results
+
+        # Test summary
+        summary = manager.get_session_tools_summary(session.id)
+        assert summary["total_tool_calls"] == 2
+        assert summary["unique_tools"] == 2
+        assert summary["tool_counts"]["read_file"] == 1
+        assert summary["tool_counts"]["write_file"] == 1
+
+        # Verify the tool calls were properly stored
+        messages = manager.get_messages(session.id)
+        tool_msg = next(msg for msg in messages if msg.tool_calls)
+        assert len(tool_msg.tool_calls) == 2
+        assert tool_msg.tool_calls[0]["name"] == "read_file"
+        assert tool_msg.tool_calls[1]["name"] == "write_file"
+
+    @pytest.mark.integration
+    def test_tool_storage_with_objects(self, tmp_path):
+        """Test tool storage with object-based tool calls."""
+        from types import SimpleNamespace
+
+        # Create database and manager
+        db_path = tmp_path / "test_tools_obj.db"
+        db = SessionDatabase(db_path)
+        manager = SessionManager(db)
+
+        # Create a session
+        session = manager.create_session(
+            name="Tool Object Test",
+            provider="test",
+            model="test-model"
+        )
+
+        # Create tool call objects
+        tool_calls = [
+            SimpleNamespace(
+                id="obj_tc1",
+                name="list_files",
+                arguments={"directory": "/home/user"}
+            )
+        ]
+
+        # Format and store
+        formatted_calls = format_tool_calls_for_storage(tool_calls)
+
+        manager.add_message(
+            session_id=session.id,
+            role="assistant",
+            content="Listing files...",
+            tool_calls=formatted_calls
+        )
+
+        # Verify
+        messages = manager.get_messages(session.id)
+        tool_msg = next(msg for msg in messages if msg.tool_calls)
+        assert tool_msg.tool_calls[0]["id"] == "obj_tc1"
+        assert tool_msg.tool_calls[0]["name"] == "list_files"
+        assert tool_msg.tool_calls[0]["arguments"]["directory"] == "/home/user"
+
+    @pytest.mark.integration
+    def test_session_tools_command_display(self, tmp_path):
+        """Test the session tools command display functionality."""
+        from coda.session.commands import SessionCommands
+
+        # Create database and manager
+        db_path = tmp_path / "test_tools_cmd.db"
+        db = SessionDatabase(db_path)
+        manager = SessionManager(db)
+
+        # Create session commands
+        commands = SessionCommands(manager)
+
+        # Create a session with tool usage
+        session = manager.create_session(
+            name="Tool Command Test",
+            provider="test",
+            model="test-model"
+        )
+
+        commands.current_session_id = session.id
+
+        # Add tool usage
+        manager.add_message(
+            session.id,
+            "assistant",
+            "Executing tools...",
+            tool_calls=[
+                {"id": "t1", "name": "search", "arguments": {"query": "test"}},
+                {"id": "t2", "name": "search", "arguments": {"query": "demo"}},
+                {"id": "t3", "name": "read", "arguments": {"file": "test.py"}}
+            ]
+        )
+
+        # Add results
+        for tid in ["t1", "t2", "t3"]:
+            manager.add_message(
+                session.id,
+                "tool",
+                f"Result for {tid}",
+                metadata={"tool_call_id": tid}
+            )
+
+        # Test command - should not return error
+        result = commands.handle_session_command(["tools"])
+        assert result is None  # Success - no error message
+
+        # Test summary data
+        summary = manager.get_session_tools_summary(session.id)
+        assert summary["total_tool_calls"] == 3
+        assert summary["unique_tools"] == 2
+        assert summary["tool_counts"]["search"] == 2
+        assert summary["tool_counts"]["read"] == 1
+        assert summary["most_used"] == "search"
+

--- a/tests/session/test_tool_storage.py
+++ b/tests/session/test_tool_storage.py
@@ -1,0 +1,225 @@
+"""Test tool call storage in sessions."""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from coda.session.database import SessionDatabase
+from coda.session.manager import SessionManager
+from coda.session.tool_storage import format_tool_calls_for_storage, format_tool_result_for_storage
+
+
+class TestToolStorage:
+    """Test tool storage functionality."""
+
+    @pytest.fixture
+    def session_manager(self, tmp_path):
+        """Create a test session manager."""
+        db_path = tmp_path / "test_tools.db"
+        db = SessionDatabase(db_path)
+        return SessionManager(db)
+
+    def test_format_tool_calls_object(self):
+        """Test formatting tool calls from objects."""
+        # Mock tool call object
+        class MockToolCall:
+            def __init__(self, id, name, arguments):
+                self.id = id
+                self.name = name
+                self.arguments = arguments
+
+        tool_calls = [
+            MockToolCall("call1", "read_file", {"path": "/test.txt"}),
+            MockToolCall("call2", "write_file", {"path": "/out.txt", "content": "data"}),
+        ]
+
+        formatted = format_tool_calls_for_storage(tool_calls)
+
+        assert len(formatted) == 2
+        assert formatted[0] == {
+            "id": "call1",
+            "name": "read_file",
+            "arguments": {"path": "/test.txt"},
+        }
+        assert formatted[1] == {
+            "id": "call2",
+            "name": "write_file",
+            "arguments": {"path": "/out.txt", "content": "data"},
+        }
+
+    def test_format_tool_calls_dict(self):
+        """Test formatting tool calls from dictionaries."""
+        tool_calls = [
+            {"id": "call1", "name": "search", "arguments": {"query": "test"}},
+            {"id": "call2", "name": "fetch", "arguments": {"url": "http://example.com"}},
+        ]
+
+        formatted = format_tool_calls_for_storage(tool_calls)
+
+        assert formatted == tool_calls
+
+    def test_format_tool_result(self):
+        """Test formatting tool results."""
+        # Object result
+        class MockResult:
+            def __init__(self, tool_call_id, content, is_error=False):
+                self.tool_call_id = tool_call_id
+                self.content = content
+                self.is_error = is_error
+
+        result = MockResult("call1", "File content here", False)
+        formatted = format_tool_result_for_storage(result)
+
+        assert formatted == {
+            "tool_call_id": "call1",
+            "content": "File content here",
+            "is_error": False,
+        }
+
+        # Dict result
+        dict_result = {"tool_call_id": "call2", "content": "Error occurred", "is_error": True}
+        formatted = format_tool_result_for_storage(dict_result)
+        assert formatted == dict_result
+
+    def test_store_tool_calls_in_session(self, session_manager):
+        """Test storing tool calls in a session."""
+        # Create session
+        session = session_manager.create_session(
+            name="Tool Test Session",
+            provider="test",
+            model="test-model",
+            mode="code",
+        )
+
+        # Add user message
+        session_manager.add_message(
+            session_id=session.id,
+            role="user",
+            content="Read the README file",
+        )
+
+        # Add assistant message with tool calls
+        tool_calls = [
+            {
+                "id": "tc_001",
+                "name": "read_file",
+                "arguments": {"path": "README.md"},
+            }
+        ]
+        session_manager.add_message(
+            session_id=session.id,
+            role="assistant",
+            content="I'll read the README file for you.",
+            tool_calls=tool_calls,
+        )
+
+        # Add tool result
+        session_manager.add_message(
+            session_id=session.id,
+            role="tool",
+            content="# Project README\n\nThis is the content of the README file.",
+            metadata={"tool_call_id": "tc_001"},
+        )
+
+        # Add final assistant response
+        session_manager.add_message(
+            session_id=session.id,
+            role="assistant",
+            content="The README file contains a project description.",
+        )
+
+        # Verify messages were stored
+        messages = session_manager.get_messages(session.id)
+        assert len(messages) == 4
+
+        # Check tool call message
+        tool_msg = messages[1]
+        assert tool_msg.role == "assistant"
+        assert tool_msg.tool_calls == tool_calls
+
+        # Check tool result message
+        result_msg = messages[2]
+        assert result_msg.role == "tool"
+        assert result_msg.message_metadata["tool_call_id"] == "tc_001"
+
+    def test_get_tool_history(self, session_manager):
+        """Test retrieving tool history."""
+        # Create session with tool interactions
+        session = session_manager.create_session(
+            name="Tool History Test",
+            provider="test",
+            model="test-model",
+        )
+
+        # Add messages with tools
+        session_manager.add_message(session.id, "user", "Analyze these files")
+        
+        session_manager.add_message(
+            session.id,
+            "assistant",
+            "I'll analyze the files.",
+            tool_calls=[
+                {"id": "t1", "name": "list_files", "arguments": {"path": "."}},
+                {"id": "t2", "name": "read_file", "arguments": {"path": "main.py"}},
+            ],
+        )
+        
+        session_manager.add_message(
+            session.id, "tool", "file1.py\nfile2.py\nmain.py", 
+            metadata={"tool_call_id": "t1"}
+        )
+        
+        session_manager.add_message(
+            session.id, "tool", "def main():\n    pass", 
+            metadata={"tool_call_id": "t2"}
+        )
+
+        # Get tool history
+        history = session_manager.get_tool_history(session.id)
+        
+        assert len(history) == 3  # 1 call message + 2 result messages
+        assert history[0]["type"] == "call"
+        assert len(history[0]["tool_calls"]) == 2
+        assert history[1]["type"] == "result"
+        assert history[2]["type"] == "result"
+
+    def test_get_session_tools_summary(self, session_manager):
+        """Test getting tool usage summary."""
+        session = session_manager.create_session(
+            name="Tool Summary Test",
+            provider="test",
+            model="test-model",
+        )
+
+        # Add multiple tool uses
+        for i in range(3):
+            session_manager.add_message(
+                session.id,
+                "assistant",
+                f"Using tools {i}",
+                tool_calls=[{"id": f"r{i}", "name": "read_file", "arguments": {}}],
+            )
+
+        session_manager.add_message(
+            session.id,
+            "assistant",
+            "Writing file",
+            tool_calls=[{"id": "w1", "name": "write_file", "arguments": {}}],
+        )
+
+        session_manager.add_message(
+            session.id,
+            "assistant",
+            "Another read",
+            tool_calls=[{"id": "r3", "name": "read_file", "arguments": {}}],
+        )
+
+        # Get summary
+        summary = session_manager.get_session_tools_summary(session.id)
+
+        assert summary["total_tool_calls"] == 5
+        assert summary["unique_tools"] == 2
+        assert summary["tool_counts"]["read_file"] == 4
+        assert summary["tool_counts"]["write_file"] == 1
+        assert summary["most_used"] == "read_file"

--- a/tests/session/test_tool_storage.py
+++ b/tests/session/test_tool_storage.py
@@ -1,7 +1,5 @@
 """Test tool call storage in sessions."""
 
-import json
-from datetime import datetime
 
 import pytest
 
@@ -154,7 +152,7 @@ class TestToolStorage:
 
         # Add messages with tools
         session_manager.add_message(session.id, "user", "Analyze these files")
-        
+
         session_manager.add_message(
             session.id,
             "assistant",
@@ -164,20 +162,20 @@ class TestToolStorage:
                 {"id": "t2", "name": "read_file", "arguments": {"path": "main.py"}},
             ],
         )
-        
+
         session_manager.add_message(
-            session.id, "tool", "file1.py\nfile2.py\nmain.py", 
+            session.id, "tool", "file1.py\nfile2.py\nmain.py",
             metadata={"tool_call_id": "t1"}
         )
-        
+
         session_manager.add_message(
-            session.id, "tool", "def main():\n    pass", 
+            session.id, "tool", "def main():\n    pass",
             metadata={"tool_call_id": "t2"}
         )
 
         # Get tool history
         history = session_manager.get_tool_history(session.id)
-        
+
         assert len(history) == 3  # 1 call message + 2 result messages
         assert history[0]["type"] == "call"
         assert len(history[0]["tool_calls"]) == 2


### PR DESCRIPTION
## Summary
- Implements Phase 4.5 of the ROADMAP: Tool Integration with Sessions
- Stores tool invocations in the session database for historical tracking
- Adds `/session tools` command to view tool usage within a session

## Changes
1. **Tool Storage Integration**
   - Modified `interactive.py` to save tool calls from agent interactions to session
   - Used existing `tool_calls` column in Message model (pre-added for Phase 5)
   - Created `tool_storage.py` module with formatting utilities

2. **Session Manager Updates**
   - Added `get_tool_history()` method to retrieve tool calls and results
   - Added `get_session_tools_summary()` method for usage statistics
   - Tool calls are stored as JSON in the database

3. **New /session tools Command**
   - Shows tool usage summary (total calls, unique tools, most used)
   - Displays chronological tool call history with results
   - Accessible via `/session tools` or `/s t`

4. **Testing**
   - Added comprehensive integration tests
   - Created manual test script to verify end-to-end functionality
   - All existing tests continue to pass

## Test Plan
- [x] Integration tests pass (`make test-integration`)
- [x] Unit tests pass (`make test`)
- [x] Manual testing with actual tool calls
- [x] Verified tool data persists across session loads
- [x] Linting passes (`make lint`)