### PR TITLE
refactor: replace diagram-renderer submodule with PyPI dependency

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -8,7 +8,6 @@ on:
       - '*.md'
       - 'LICENSE'
       - 'archive/**'
-      - '**/diagram_renderer/**'
   pull_request:
     branches: [ main ]
     paths-ignore:
@@ -16,7 +15,6 @@ on:
       - '*.md'
       - 'LICENSE'
       - 'archive/**'
-      - '**/diagram_renderer/**'
 
 permissions:
   contents: read
@@ -38,8 +36,8 @@ jobs:
     
     - name: Run lint checks
       run: |
-        uv run ruff check . --exclude archive --exclude "*/diagram_renderer/*"
+        uv run ruff check . --exclude archive
     
     - name: Check code formatting
       run: |
-        uv run ruff format --check . --exclude archive --exclude "*/diagram_renderer/*"
+        uv run ruff format --check . --exclude archive

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "docs/wiki"]
 	path = docs/wiki
 	url = git@github.com:djvolz/coda-code-assistant.wiki.git
-[submodule "coda/base/diagram_renderer"]
-	path = coda/base/diagram_renderer
-	url = https://github.com/djvolz/diagram-renderer.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,14 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        exclude: "*/diagram_renderer/*"
 
   # Ruff - Fast Python linter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.8.0
     hooks:
       - id: ruff
-        args: [--fix, --exclude, "*/diagram_renderer/*"]
+        args: [--fix]
       - id: ruff-format
-        exclude: "*/diagram_renderer/*"
 
   # Pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/coda/apps/web/components/chat_widget.py
+++ b/coda/apps/web/components/chat_widget.py
@@ -2,15 +2,10 @@
 
 import asyncio
 import re
-import sys
 from datetime import datetime
-from pathlib import Path
 
 import streamlit as st
 import streamlit.components.v1 as components
-
-# Add diagram_renderer to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "base" / "diagram_renderer"))
 
 from coda.apps.web.utils.state import get_state_value, set_state_value
 from coda.base.providers.registry import ProviderFactory

--- a/coda/services/tools/diagram_tools.py
+++ b/coda/services/tools/diagram_tools.py
@@ -4,12 +4,8 @@ Diagram rendering tool using the diagram-renderer library.
 This tool provides diagram rendering capabilities for Mermaid, PlantUML, and Graphviz diagrams.
 """
 
-import sys
 from pathlib import Path
 from typing import Any
-
-# Add diagram_renderer to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "base" / "diagram_renderer"))
 
 from diagram_renderer import DiagramRenderer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
     "opentelemetry-instrumentation>=0.41b0",
+    "diagram-renderer>=0.1.0",
 ]
 
 [project.scripts]

--- a/tests/base/test_module_independence.py
+++ b/tests/base/test_module_independence.py
@@ -169,29 +169,6 @@ def test_observability_module_independence():
         )
 
 
-def test_diagram_renderer_module_independence():
-    """Test that diagram_renderer module has no service/app dependencies."""
-    base_path = Path(__file__).parent.parent.parent / "coda" / "base" / "diagram_renderer"
-
-    # Skip if the module doesn't exist (e.g., submodule not initialized)
-    if not base_path.exists():
-        return
-
-    imports = get_all_imports_in_module(base_path)
-
-    violations = check_forbidden_imports(imports, "diagram_renderer")
-    assert not violations, "\n".join(violations)
-
-    # Check that it only imports from allowed modules
-    coda_imports = {imp for imp in imports if imp.startswith("coda.")}
-    allowed_prefixes = ["coda.base."]
-
-    for imp in coda_imports:
-        assert any(imp.startswith(prefix) for prefix in allowed_prefixes), (
-            f"diagram_renderer: Unexpected import '{imp}'"
-        )
-
-
 def test_all_base_modules_found():
     """Ensure we're testing all base modules."""
     base_path = Path(__file__).parent.parent.parent / "coda" / "base"
@@ -211,7 +188,6 @@ def test_all_base_modules_found():
         "search",
         "session",
         "observability",
-        "diagram_renderer",
     }
 
     # Make sure we're not missing any

--- a/uv.lock
+++ b/uv.lock
@@ -524,6 +524,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "click" },
     { name = "cryptography" },
+    { name = "diagram-renderer" },
     { name = "faiss-cpu" },
     { name = "grep-ast" },
     { name = "httpx" },
@@ -590,6 +591,7 @@ requires-dist = [
     { name = "chromadb", marker = "extra == 'embeddings'", specifier = ">=0.4.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "cryptography", specifier = ">=3.4.7" },
+    { name = "diagram-renderer", specifier = ">=0.1.0" },
     { name = "faiss-cpu", specifier = ">=1.7.4" },
     { name = "grep-ast", specifier = ">=0.9.0" },
     { name = "httpx", specifier = ">=0.25.0" },
@@ -764,6 +766,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/38/6bf177ca6bce4fe14704ab3e93627c5b0ca05242261a2e43ef3168472540/cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:12e55281d993a793b0e883066f590c1ae1e802e3acb67f8b442e721e475e6463", size = 4151627, upload-time = "2025-07-02T13:06:13.097Z" },
     { url = "https://files.pythonhosted.org/packages/38/6a/69fc67e5266bff68a91bcb81dff8fb0aba4d79a78521a08812048913e16f/cryptography-45.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:5aa1e32983d4443e310f726ee4b071ab7569f58eedfdd65e9675484a4eb67bd1", size = 4385593, upload-time = "2025-07-02T13:06:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/f6/34/31a1604c9a9ade0fdab61eb48570e09a796f4d9836121266447b0eaf7feb/cryptography-45.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:e357286c1b76403dd384d938f93c46b2b058ed4dfcdce64a770f0537ed3feb6f", size = 3331106, upload-time = "2025-07-02T13:06:18.058Z" },
+]
+
+[[package]]
+name = "diagram-renderer"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/5f/98779309fa3d7235346923216ec519e551a8124a722f98e9ce03c5798091/diagram_renderer-0.1.0.tar.gz", hash = "sha256:69ce8d03e1b0ab3ab56ee76627bdf45705f666c102eda60c8e5ea6a6c5cbabaf", size = 1435449, upload-time = "2025-07-01T04:05:11.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/4c/1cdb8012dbb33bd8fb5b8e04c225216dac3c9b84ddda77415a0eb756f8ad/diagram_renderer-0.1.0-py3-none-any.whl", hash = "sha256:64b8a5f8dbf2c5f67e99178bf6b9b3c2a1a9cb8bde6e35f5f718c95f7f6b6940", size = 1449630, upload-time = "2025-07-01T04:05:07.235Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the git submodule `coda/base/diagram_renderer` with the `diagram-renderer` package from PyPI. This simplifies dependency management and eliminates the need for submodule initialization during setup.

### Changes Made

- ✅ **Removed git submodule**: Completely removed `coda/base/diagram_renderer` submodule
- ✅ **Added PyPI dependency**: Added `diagram-renderer>=0.1.0` via `uv add`
- ✅ **Updated imports**: Removed `sys.path` manipulation from `diagram_tools.py` and `chat_widget.py`
- ✅ **Cleaned up configuration**: Removed diagram_renderer exclusions from:
  - `.pre-commit-config.yaml` (Black, Ruff formatting and linting)
  - `.github/workflows/quality-checks.yml` (CI/CD paths-ignore and exclusions)
- ✅ **Updated tests**: Removed diagram_renderer from module independence tests
- ✅ **Verified functionality**: All imports work correctly, tests pass, linting passes

## Test Results

### ✅ Import Verification
```bash
uv run python -c "from diagram_renderer import DiagramRenderer; print('✅ diagram_renderer import successful')"
# ✅ diagram_renderer import successful

uv run python -c "from coda.services.tools.diagram_tools import RenderDiagramTool; print('✅ diagram_tools import successful')"
# ✅ diagram_tools import successful
```

### ✅ Code Quality Checks
```bash
make lint
# All checks passed\!

make format  
# Code formatted ✓
```

### ✅ Module Independence Tests
```bash
uv run pytest tests/base/test_module_independence.py -v
# 8 passed in 0.15s
```

## Benefits

- **Simplified setup**: No need to initialize git submodules
- **Standard dependency management**: Uses standard PyPI package installation
- **Cleaner codebase**: Removes sys.path manipulation workarounds
- **Better CI/CD**: No special exclusions needed for linting and formatting
- **Easier maintenance**: Package updates through standard dependency management

## Test Plan

- [x] Verify diagram renderer imports work correctly
- [x] Run all module independence tests  
- [x] Verify linting and formatting pass
- [x] Check that diagram functionality still works via tool instantiation
- [x] Confirm no broken imports or missing dependencies

---

## AI Development Summary

**Context**: User requested removing the diagram renderer git submodule and replacing it with the PyPI package.

**Approach**: 
1. Systematic removal of git submodule using proper git commands
2. Addition of PyPI dependency via `uv add`
3. Comprehensive cleanup of all submodule-related configurations
4. Thorough testing to ensure functionality preservation

**Key Tools Used**:
- `TodoWrite`: Task planning and progress tracking
- `Bash`: Git operations, dependency management, testing
- `Edit`: Code modifications and cleanup
- `Grep`: Finding references and dependencies
- `Read`: Analyzing file contents

**Verification**: All functionality verified through import tests, code quality checks, and module independence tests.